### PR TITLE
Read binary with xmitgcm

### DIFF
--- a/ecco_v4_py/__init__.py
+++ b/ecco_v4_py/__init__.py
@@ -14,7 +14,7 @@ from .llc_array_conversion  import llc_tiles_to_compact
 
 
 from .read_bin_llc import read_llc_to_tiles, read_llc_to_compact, read_llc_to_faces
-from .read_bin_gen import read_binary_array
+from .read_bin_gen import load_binary_array
 
 from .resample_to_latlon import resample_to_latlon
 
@@ -46,9 +46,10 @@ from .tile_rotation import reorient_13_tile_Dataset_to_latlon_layout_UV_points
 from .tile_rotation import rotate_single_tile_Datasets_UV_points
 from .tile_rotation import rotate_single_tile_DataArrays_UV_points
 
-from .test_llc_array_loading_and_conversion import run_mds_io_and_llc_conversion_test
+from .test_llc_array_loading_and_conversion import run_read_bin_and_llc_conversion_test
 
 __all__ = ['extract_grid_fields_from_mitgrid_files', 'dataset_utils',
-           'llc_array_conversion', 'mds_io', 'resample_to_latlon', 
+           'llc_array_conversion', 'read_bin_llc','read_bin_gen', 
+           'resample_to_latlon', 
            'tile_exchange', 'tile_io', 'tile_plot','tile_plot_proj', 
-           'tile_rotation', 'test_mds_io_and_conversion']
+           'tile_rotation', 'test_read_bin_and_conversion']

--- a/ecco_v4_py/__init__.py
+++ b/ecco_v4_py/__init__.py
@@ -1,54 +1,54 @@
-from ecco_utils import minimal_metadata
-from ecco_utils import months2days
-from ecco_utils import createShapefileFromXY
+from .ecco_utils import minimal_metadata
+from .ecco_utils import months2days
+from .ecco_utils import createShapefileFromXY
 
 #from extract_grid_fields_from_mitgrid_files import extract_U_point_grid_fields_from_mitgrid_as_tiles
 #from extract_grid_fields_from_mitgrid_files import extract_G_point_grid_fields_from_mitgrid_as_tiles
 
-from llc_array_conversion  import llc_compact_to_tiles
-from llc_array_conversion  import llc_compact_to_faces
-from llc_array_conversion  import llc_faces_to_tiles
-from llc_array_conversion  import llc_faces_to_compact
-from llc_array_conversion  import llc_tiles_to_faces
-from llc_array_conversion  import llc_tiles_to_compact
+from .llc_array_conversion  import llc_compact_to_tiles
+from .llc_array_conversion  import llc_compact_to_faces
+from .llc_array_conversion  import llc_faces_to_tiles
+from .llc_array_conversion  import llc_faces_to_compact
+from .llc_array_conversion  import llc_tiles_to_faces
+from .llc_array_conversion  import llc_tiles_to_compact
 
 
-from mds_io import load_binary_array
-from mds_io import load_llc_compact
-from mds_io import load_llc_compact_to_faces
-from mds_io import load_llc_compact_to_tiles
+from .mds_io import load_binary_array
+from .mds_io import load_llc_compact
+from .mds_io import load_llc_compact_to_faces
+from .mds_io import load_llc_compact_to_tiles
 
 from .resample_to_latlon import resample_to_latlon
 
-from tile_exchange import append_border_to_tile
-from tile_exchange import add_borders_to_DataArray_V_points
-from tile_exchange import add_borders_to_DataArray_U_points
-from tile_exchange import add_borders_to_DataArray_G_points
-from tile_exchange import get_llc_tile_border_mapping
-from tile_exchange import add_borders_to_GRID_tiles
+from .tile_exchange import append_border_to_tile
+from .tile_exchange import add_borders_to_DataArray_V_points
+from .tile_exchange import add_borders_to_DataArray_U_points
+from .tile_exchange import add_borders_to_DataArray_G_points
+from .tile_exchange import get_llc_tile_border_mapping
+from .tile_exchange import add_borders_to_GRID_tiles
 
-from tile_io import load_all_tiles_from_netcdf
-from tile_io import load_tile_from_netcdf
-from tile_io import load_subset_tiles_from_netcdf
+from .tile_io import load_all_tiles_from_netcdf
+from .tile_io import load_tile_from_netcdf
+from .tile_io import load_subset_tiles_from_netcdf
 
-from tile_plot import plot_tile
-from tile_plot import plot_tiles
-from tile_plot import unique_color
+from .tile_plot import plot_tile
+from .tile_plot import plot_tiles
+from .tile_plot import unique_color
 
-from tile_plot_proj import plot_proj_to_latlon_grid
-from tile_plot_proj import plot_pstereo
-from tile_plot_proj import plot_global
+from .tile_plot_proj import plot_proj_to_latlon_grid
+from .tile_plot_proj import plot_pstereo
+from .tile_plot_proj import plot_global
 
 
-from tile_rotation import reorient_13_tile_GRID_Dataset_to_latlon_layout
-from tile_rotation import reorient_13_tile_Dataset_to_latlon_layout_CG_points
-from tile_rotation import rotate_single_tile_Dataset_CG_points
-from tile_rotation import rotate_single_tile_DataArray_CG_points
-from tile_rotation import reorient_13_tile_Dataset_to_latlon_layout_UV_points
-from tile_rotation import rotate_single_tile_Datasets_UV_points
-from tile_rotation import rotate_single_tile_DataArrays_UV_points
+from .tile_rotation import reorient_13_tile_GRID_Dataset_to_latlon_layout
+from .tile_rotation import reorient_13_tile_Dataset_to_latlon_layout_CG_points
+from .tile_rotation import rotate_single_tile_Dataset_CG_points
+from .tile_rotation import rotate_single_tile_DataArray_CG_points
+from .tile_rotation import reorient_13_tile_Dataset_to_latlon_layout_UV_points
+from .tile_rotation import rotate_single_tile_Datasets_UV_points
+from .tile_rotation import rotate_single_tile_DataArrays_UV_points
 
-from test_llc_array_loading_and_conversion import run_mds_io_and_llc_conversion_test
+from .test_llc_array_loading_and_conversion import run_mds_io_and_llc_conversion_test
 
 __all__ = ['extract_grid_fields_from_mitgrid_files', 'dataset_utils',
            'llc_array_conversion', 'mds_io', 'resample_to_latlon', 

--- a/ecco_v4_py/__init__.py
+++ b/ecco_v4_py/__init__.py
@@ -14,6 +14,7 @@ from .llc_array_conversion  import llc_tiles_to_compact
 
 
 from .read_bin_llc import read_llc_to_tiles, read_llc_to_compact, read_llc_to_faces
+from .read_bin_gen import read_binary_array
 
 from .resample_to_latlon import resample_to_latlon
 

--- a/ecco_v4_py/__init__.py
+++ b/ecco_v4_py/__init__.py
@@ -13,10 +13,7 @@ from .llc_array_conversion  import llc_tiles_to_faces
 from .llc_array_conversion  import llc_tiles_to_compact
 
 
-from .mds_io import load_binary_array
-from .mds_io import load_llc_compact
-from .mds_io import load_llc_compact_to_faces
-from .mds_io import load_llc_compact_to_tiles
+from .mds_io import read_bin_to_tiles, read_bin_to_compact, read_bin_to_faces
 
 from .resample_to_latlon import resample_to_latlon
 

--- a/ecco_v4_py/__init__.py
+++ b/ecco_v4_py/__init__.py
@@ -13,7 +13,7 @@ from .llc_array_conversion  import llc_tiles_to_faces
 from .llc_array_conversion  import llc_tiles_to_compact
 
 
-from .mds_io import read_bin_to_tiles, read_bin_to_compact, read_bin_to_faces
+from .read_bin_llc import read_llc_to_tiles, read_llc_to_compact, read_llc_to_faces
 
 from .resample_to_latlon import resample_to_latlon
 

--- a/ecco_v4_py/mds_io.py
+++ b/ecco_v4_py/mds_io.py
@@ -12,12 +12,9 @@ from __future__ import division,print_function
 import numpy as np
 import glob
 
-from llc_array_conversion  import llc_compact_to_tiles
-from llc_array_conversion  import llc_compact_to_faces
-from llc_array_conversion  import llc_faces_to_tiles
-from llc_array_conversion  import llc_faces_to_compact
-from llc_array_conversion  import llc_tiles_to_faces
-from llc_array_conversion  import llc_tiles_to_compact
+from .llc_array_conversion  import llc_compact_to_tiles, \
+    llc_compact_to_faces, llc_faces_to_tiles, llc_faces_to_compact, \
+    llc_tiles_to_faces, llc_tiles_to_compact
 
 #%%
 def load_binary_array(fdir, fname, ni, nj, nk=1, nl=1, skip=0, 

--- a/ecco_v4_py/mds_io.py
+++ b/ecco_v4_py/mds_io.py
@@ -27,7 +27,7 @@ def read_bin_to_tiles(fdir, fname, llc=90, skip=0, nk=1, nl=1,
 
     Array is returned with the following dimension order:
 
-        [N_tiles, N_recs, N_z, N_y, N_x]
+        [N_tiles, N_recs, N_z, llc, llc]
 
     where if either N_z or N_recs =1, then that dimension is collapsed
     and not present in the returned array.
@@ -74,7 +74,7 @@ def read_bin_to_tiles(fdir, fname, llc=90, skip=0, nk=1, nl=1,
     nrecs += skip_3d
 
     # Reads data into dask array as numpy memmap 
-    # [Nrecs x Nz x Ntiles x Ny x Nx]
+    # [Nrecs x Nz x Ntiles x llc x llc]
     data_tiles = xmitgcm.utils.read_3d_llc_data(full_filename, nx=llc, nz=nk,
                                                 nrecs=nrecs, dtype=filetype)
 
@@ -109,7 +109,7 @@ def read_bin_to_compact(fdir, fname, llc=90, skip=0, nk=1, nl=1,
 
     Array is returned with the following dimension order:
 
-        [N_recs, N_z, N_y, N_x]
+        [N_recs, N_z, N_tiles*llc, llc]
 
     where if either N_z or N_recs =1, then that dimension is collapsed 
     and not present in the returned array.
@@ -145,7 +145,7 @@ def read_bin_to_compact(fdir, fname, llc=90, skip=0, nk=1, nl=1,
     Returns
     -------
     data_compact
-        a numpy array of dimension nl x nk x llc x llc 
+        a numpy array of dimension nl x nk x 13*llc x llc 
 
     """
 
@@ -205,10 +205,10 @@ def read_bin_to_faces(fdir, fname, llc=90, skip=0, nk=1, nl=1,
         
     Returns
     -------
-    F : a dictionary containing the five lat-lon-cap faces
-        F[n] is a numpy array of face n, n in [1..5]
+    data_faces : a dictionary containing the five lat-lon-cap faces
+        data_faces[n] is a numpy array of face n, n in [1..5]
 
-    - dimensions of each 2D slice of F
+    - dimensions of each 2D slice of data_faces
         f1,f2: 3*llc x llc
            f3: llc x llc
         f4,f5: llc x 3*llc  

--- a/ecco_v4_py/mds_io.py
+++ b/ecco_v4_py/mds_io.py
@@ -130,7 +130,6 @@ def read_bin_to_compact(fdir, fname, llc=90, skip=0, nk=1, nl=1,
         Default: 0
     nk : int
         number of 2D slices (or records) to load in the third dimension.  
-        if nk = -1, load all 2D slices
         Default: 1 [singleton]
     nl : int
         number of 2D slices (or records) to load in the fourth dimension.  
@@ -193,7 +192,6 @@ def read_bin_to_faces(fdir, fname, llc=90, skip=0, nk=1, nl=1,
         vertical levels of a 3D field, or different 2D fields, or both.
     nk : int
         number of 2D slices (or records) to load in the third dimension.  
-        if nk = -1, load all 2D slices
         Default: 1 [singleton]
     nl : int
         number of 2D slices (or records) to load in the fourth dimension.  

--- a/ecco_v4_py/mds_io.py
+++ b/ecco_v4_py/mds_io.py
@@ -78,10 +78,6 @@ def read_bin_to_tiles(fdir, fname, llc=90, skip=0, nk=1, nl=1,
     data_tiles = xmitgcm.utils.read_3d_llc_data(full_filename, nx=llc, nz=nk,
                                                 nrecs=nrecs, dtype=filetype)
 
-    print('---')
-    print(np.shape(data_tiles))
-    print('---')
-
     # Handle cases of single or multiple records, and skip>0
     # Also, swap so that Ntiles dim is ALWAYS first 
     # for ecco_v4_py convention

--- a/ecco_v4_py/read_bin_gen.py
+++ b/ecco_v4_py/read_bin_gen.py
@@ -1,0 +1,137 @@
+"""ECCO v4 Python: read_bin_gen
+
+This module includes utility routines for loading general binary files, 
+not necessarily in the lat-lon-cap layout. For LLC type data, see read_bin_llc. 
+
+.. _ecco_v4_py Documentation :
+   https://github.com/ECCO-GROUP/ECCOv4-py
+"""
+
+from __future__ import division,print_function
+import numpy as np
+import glob
+#%%
+def load_binary_array(fdir, fname, ni, nj, nk=1, nl=1, skip=0, 
+                      filetype = '>f', less_output = False ):
+    """
+    Note: This function is for reading a general binary file. To read data in
+    the llc structure, see read_bin_llc. 
+
+    Loads a binary array from a file into memory, which is not necessarily in
+    llc format.  The first two dimensions
+    of the array have length ni and nj, respectively.  The array is comprised
+    of one or more 2D 'slices' of dimension ni x nj.  The number of 2D slices
+    to read is 'nk'.  nk is not necessarily the length of the third dimension
+    of the file.  The 'skip' parameter specifies the number of 2D slices
+    to skip over before reading the nk number of 2D slices.  nk can be 1.
+
+    Parameters
+    ----------
+    fdir : string
+        A string with the directory of the binary file to open
+    fname : string
+        A string with the name of the binary file to open
+    ni,nj : int
+        the length of each array dimension.  ni, nj must be > 0
+    skip : int
+        the number of 2D (nj x ni) slices to skip.
+        Default: 0
+    nk : int
+        number of 2D slices (or records) to load in the third dimension.  
+        if nk = -1, load all 2D slices
+        Default: 1 [singleton]
+    nl : int
+        number of 2D slices (or records) to load in the fourth dimension.  
+        Default: 1 [singleton]
+    filetype: string
+        the file type, default is big endian (>) 32 bit float (f)
+        alternatively, ('<d') would be little endian (<) 64 bit float (d)
+        Default '>f'
+    less_output : boolean
+        A debugging flag.  False = less debugging output
+        Default: False
+        
+    Returns
+    -------
+    data
+        a numpy array with dimensions nl x nk x nj x ni
+        
+    Raises
+    ------
+    IOError
+        If the file is not found
+
+    """
+    datafile = fdir + '/' + fname
+    
+    if less_output == False:
+        print('loading ', fname)
+    
+    # check to see if file exists.    
+    file = glob.glob(datafile)
+    if len(file) == 0:
+        raise IOError(fname + ' not found ')
+
+    f = open(datafile, 'rb')
+    dt = np.dtype(filetype)
+
+    if skip > 0:
+        # skip ahead 'skip' number of 2D slices
+        f.seek(ni*nj*skip*dt.itemsize)
+
+    if (ni <= 0) or (nj <= 0):
+        print('ni and nj must be > 1')
+        return []
+
+    # load all 2D records
+    if nk == -1:
+        # nl can only be 1 if we use nk = -1
+        nl = 1
+        # read all 2D records
+        arr_k = np.fromfile(f, dtype=filetype, count=-1)
+        # find the number of 2D records (nk)
+        length_arr_k = len(arr_k)
+
+        # length of each 2D slice is ni * nj
+        nk = int(length_arr_k / (ni*nj))
+
+        if less_output == False:
+            print('loading all 2D records.  nk =',nk)
+        
+        # reshape the array to 2D records
+        if nk > 1: # we have more than one 2D record, make 3D field
+            data = np.reshape(arr_k,(nk, nj, ni))
+        
+        else: # nk = 1, just make 2D field
+            data = np.reshape(arr_k,(nj, ni))
+
+    # read a specific number of records (nk*nl)
+    else:
+        if (nk <= 0) or (nl <= 0):
+            print('nk and nl must be > 0.  If they are singleton dimensions, use 1')
+            return []
+
+        # read in nk*nl 2D records
+        arr_k = np.fromfile(f, dtype=filetype, count=ni*nj*nk*nl)
+
+        # put data into 2D records
+        #  - if we have a fourth dimension
+        if nl > 1:
+            data = np.reshape(arr_k,(nl, nk, nj, ni))
+        
+        #  - if we have a third dimension
+        elif nk > 1:
+            data = np.reshape(arr_k,(nk, nj, ni))
+        
+        #  - if we only have two dimensions
+        else:
+            data = np.reshape(arr_k,(nj, ni))
+    
+    f.close()
+       
+    
+    if less_output == False:
+        print('data shape ', data.shape)
+
+    return data
+

--- a/ecco_v4_py/read_bin_gen.py
+++ b/ecco_v4_py/read_bin_gen.py
@@ -10,6 +10,8 @@ not necessarily in the lat-lon-cap layout. For LLC type data, see read_bin_llc.
 from __future__ import division,print_function
 import numpy as np
 import glob
+
+
 #%%
 def load_binary_array(fdir, fname, ni, nj, nk=1, nl=1, skip=0, 
                       filetype = '>f', less_output = False ):
@@ -134,4 +136,3 @@ def load_binary_array(fdir, fname, ni, nj, nk=1, nl=1, skip=0,
         print('data shape ', data.shape)
 
     return data
-

--- a/ecco_v4_py/read_bin_llc.py
+++ b/ecco_v4_py/read_bin_llc.py
@@ -1,16 +1,15 @@
-#!/usr/bin/env python2
-# -*- coding: utf-8 -*-
-"""ECCO v4 Python: mds_io
+"""ECCO v4 Python: read_bin_llc
 
-This module includes utility routines for loading binary files in the llc 13-tile native flat binary layout.  This layout is the default for MITgcm input and output for global setups using lat-lon-cap (llc) layout.  The llc layout is used for ECCO v4. 
+This module includes utility routines for loading binary files in the 
+llc 13-tile native flat binary layout.  This layout is the default for 
+MITgcm input and output for global setups using lat-lon-cap (llc) layout. 
+The llc layout is used for ECCO v4. 
 
 .. _ecco_v4_py Documentation :
    https://github.com/ECCO-GROUP/ECCOv4-py
 """
 
 from __future__ import division,print_function
-import numpy as np
-import glob
 import xmitgcm
 
 from .llc_array_conversion  import llc_compact_to_tiles, \
@@ -21,7 +20,6 @@ from .llc_array_conversion  import llc_compact_to_tiles, \
 def read_llc_to_tiles(fdir, fname, llc=90, skip=0, nk=1, nl=1, 
                       filetype = '>f'):
     """
-
     Loads an MITgcm binary file in the 'tiled' format of the 
     lat-lon-cap (LLC) grids via xmitgcm.  
 

--- a/ecco_v4_py/read_bin_llc.py
+++ b/ecco_v4_py/read_bin_llc.py
@@ -18,7 +18,7 @@ from .llc_array_conversion  import llc_compact_to_tiles, \
     llc_tiles_to_faces, llc_tiles_to_compact
 
 #%%
-def read_bin_to_tiles(fdir, fname, llc=90, skip=0, nk=1, nl=1, 
+def read_llc_to_tiles(fdir, fname, llc=90, skip=0, nk=1, nl=1, 
                       filetype = '>f'):
     """
 
@@ -100,7 +100,7 @@ def read_bin_to_tiles(fdir, fname, llc=90, skip=0, nk=1, nl=1,
     return data_tiles
 
 #%%
-def read_bin_to_compact(fdir, fname, llc=90, skip=0, nk=1, nl=1, 
+def read_llc_to_compact(fdir, fname, llc=90, skip=0, nk=1, nl=1, 
             filetype = '>f', less_output = False ):
     """
 
@@ -149,7 +149,7 @@ def read_bin_to_compact(fdir, fname, llc=90, skip=0, nk=1, nl=1,
 
     """
 
-    data_tiles = read_bin_to_tiles(fdir,fname,llc=llc,nk=nk,nl=nl,skip=skip,
+    data_tiles = read_llc_to_tiles(fdir,fname,llc=llc,nk=nk,nl=nl,skip=skip,
                                    filetype=filetype)
 
     data_compact = llc_tiles_to_compact(data_tiles,less_output=less_output)
@@ -160,7 +160,7 @@ def read_bin_to_compact(fdir, fname, llc=90, skip=0, nk=1, nl=1,
 
 
 #%%
-def read_bin_to_faces(fdir, fname, llc=90, skip=0, nk=1, nl=1,
+def read_llc_to_faces(fdir, fname, llc=90, skip=0, nk=1, nl=1,
         filetype = '>f', less_output = False):
     """
 
@@ -215,7 +215,7 @@ def read_bin_to_faces(fdir, fname, llc=90, skip=0, nk=1, nl=1,
         
     """
     
-    data_tiles = read_bin_to_tiles(fdir,fname,llc=llc,nk=nk,nl=nl,skip=skip,
+    data_tiles = read_llc_to_tiles(fdir,fname,llc=llc,nk=nk,nl=nl,skip=skip,
                                    filetype=filetype)
 
     data_faces = llc_tiles_to_faces(data_tiles, less_output = less_output)

--- a/ecco_v4_py/test_llc_array_loading_and_conversion.py
+++ b/ecco_v4_py/test_llc_array_loading_and_conversion.py
@@ -18,9 +18,7 @@ from .llc_array_conversion  import llc_tiles_to_faces
 from .llc_array_conversion  import llc_tiles_to_compact
 
 
-from .mds_io import load_llc_compact
-from .mds_io import load_llc_compact_to_faces
-from .mds_io import load_llc_compact_to_tiles
+from .mds_io import read_bin_to_compact, read_bin_to_faces, read_bin_to_tiles
 from .tile_plot import plot_tiles
 
 
@@ -78,9 +76,12 @@ def run_mds_io_and_llc_conversion_test(llc_grid_dir, llc_lons_fname='XC.data',
     # %% ----------- TEST 1: 2D field XC FOM GRID FILE
     
     #%% 1a LOAD COMPACT
-    tmpXC_c = load_llc_compact(llc_grid_dir, llc_lons_fname, llc=llc, nk=-1)
-    tmpXC_f = load_llc_compact_to_faces(llc_grid_dir, llc_lons_fname, llc=llc, nk=-1)
-    tmpXC_t = load_llc_compact_to_tiles(llc_grid_dir, llc_lons_fname, llc=llc, nk=-1)
+    tmpXC_c = read_bin_to_compact(llc_grid_dir, llc_lons_fname, llc=llc,
+                                  filetype=llc_grid_filetype)
+    tmpXC_f = read_bin_to_faces(llc_grid_dir, llc_lons_fname, llc=llc,
+                                filetype=llc_grid_filetype)
+    tmpXC_t = read_bin_to_tiles(llc_grid_dir, llc_lons_fname, llc=llc,
+                                filetype=llc_grid_filetype)
     
     if make_plots:
         #plt.close('all')
@@ -180,9 +181,12 @@ def run_mds_io_and_llc_conversion_test(llc_grid_dir, llc_lons_fname='XC.data',
     # %% ----------- TEST 2: 3D fields HFACC FOM GRID FILE
     
     #%% 2a LOAD COMPACT
-    tmpHF_c = load_llc_compact(llc_grid_dir, llc_hfacc_fname, llc=llc,nk=-1)
-    tmpHF_f = load_llc_compact_to_faces(llc_grid_dir, llc_hfacc_fname, llc=llc, nk=-1)
-    tmpHF_t = load_llc_compact_to_tiles(llc_grid_dir, llc_hfacc_fname, llc=llc, nk=-1)
+    tmpHF_c = read_bin_to_compact(llc_grid_dir, llc_hfacc_fname, llc=llc,nk=50,
+                                  filetype=llc_grid_filetype)
+    tmpHF_f = read_bin_to_faces(llc_grid_dir, llc_hfacc_fname, llc=llc, nk=50,
+                                  filetype=llc_grid_filetype)
+    tmpHF_t = read_bin_to_tiles(llc_grid_dir, llc_hfacc_fname, llc=llc, nk=50,
+                                  filetype=llc_grid_filetype)
     
     tmpHF_c.shape
     

--- a/ecco_v4_py/test_llc_array_loading_and_conversion.py
+++ b/ecco_v4_py/test_llc_array_loading_and_conversion.py
@@ -18,23 +18,23 @@ from .llc_array_conversion  import llc_tiles_to_faces
 from .llc_array_conversion  import llc_tiles_to_compact
 
 
-from .mds_io import read_bin_to_compact, read_bin_to_faces, read_bin_to_tiles
+from .read_bin_llc import read_llc_to_compact, read_llc_to_faces, read_llc_to_tiles
 from .tile_plot import plot_tiles
 
 
-# Tests the mds_io and llc_array_conversion routines
+# Tests the read_bin_llc and llc_array_conversion routines
 # %%
 ### Load model grid coordinates (longitude, latitude)
 
 
-def run_mds_io_and_llc_conversion_test(llc_grid_dir, llc_lons_fname='XC.data', 
-                                   llc_hfacc_fname='hFacC.data', llc=90, 
-                                   llc_grid_filetype = '>f', 
-                                   make_plots=False):
+def run_read_bin_and_llc_conversion_test(llc_grid_dir, llc_lons_fname='XC.data', 
+                                         llc_hfacc_fname='hFacC.data', llc=90, 
+                                         llc_grid_filetype = '>f', 
+                                         make_plots=False):
 
     """
 
-    Runs test on the mds_io and llc_conversion routines
+    Runs test on the read_bin_llc and llc_conversion routines
 
 
     Parameters
@@ -76,11 +76,11 @@ def run_mds_io_and_llc_conversion_test(llc_grid_dir, llc_lons_fname='XC.data',
     # %% ----------- TEST 1: 2D field XC FOM GRID FILE
     
     #%% 1a LOAD COMPACT
-    tmpXC_c = read_bin_to_compact(llc_grid_dir, llc_lons_fname, llc=llc,
+    tmpXC_c = read_llc_to_compact(llc_grid_dir, llc_lons_fname, llc=llc,
                                   filetype=llc_grid_filetype)
-    tmpXC_f = read_bin_to_faces(llc_grid_dir, llc_lons_fname, llc=llc,
+    tmpXC_f = read_llc_to_faces(llc_grid_dir, llc_lons_fname, llc=llc,
                                 filetype=llc_grid_filetype)
-    tmpXC_t = read_bin_to_tiles(llc_grid_dir, llc_lons_fname, llc=llc,
+    tmpXC_t = read_llc_to_tiles(llc_grid_dir, llc_lons_fname, llc=llc,
                                 filetype=llc_grid_filetype)
     
     if make_plots:
@@ -181,11 +181,11 @@ def run_mds_io_and_llc_conversion_test(llc_grid_dir, llc_lons_fname='XC.data',
     # %% ----------- TEST 2: 3D fields HFACC FOM GRID FILE
     
     #%% 2a LOAD COMPACT
-    tmpHF_c = read_bin_to_compact(llc_grid_dir, llc_hfacc_fname, llc=llc,nk=50,
+    tmpHF_c = read_llc_to_compact(llc_grid_dir, llc_hfacc_fname, llc=llc,nk=50,
                                   filetype=llc_grid_filetype)
-    tmpHF_f = read_bin_to_faces(llc_grid_dir, llc_hfacc_fname, llc=llc, nk=50,
+    tmpHF_f = read_llc_to_faces(llc_grid_dir, llc_hfacc_fname, llc=llc, nk=50,
                                   filetype=llc_grid_filetype)
-    tmpHF_t = read_bin_to_tiles(llc_grid_dir, llc_hfacc_fname, llc=llc, nk=50,
+    tmpHF_t = read_llc_to_tiles(llc_grid_dir, llc_hfacc_fname, llc=llc, nk=50,
                                   filetype=llc_grid_filetype)
     
     tmpHF_c.shape
@@ -322,7 +322,7 @@ if __name__== "__main__":
     llc_grid_filetype = '>f', 
     make_plots=False
     #%%
-    TEST_RESULT = ecco.run_mds_io_and_llc_conversion_test(llc_grid_dir, make_plots=True)
+    TEST_RESULT = ecco.run_read_bin_and_llc_conversion_test(llc_grid_dir, make_plots=True)
 
     print(TEST_RESULT)
 

--- a/ecco_v4_py/test_llc_array_loading_and_conversion.py
+++ b/ecco_v4_py/test_llc_array_loading_and_conversion.py
@@ -10,18 +10,18 @@ from __future__ import division
 import numpy as np
 import matplotlib.pylab as plt
 
-from llc_array_conversion  import llc_compact_to_tiles
-from llc_array_conversion  import llc_compact_to_faces
-from llc_array_conversion  import llc_faces_to_tiles
-from llc_array_conversion  import llc_faces_to_compact
-from llc_array_conversion  import llc_tiles_to_faces
-from llc_array_conversion  import llc_tiles_to_compact
+from .llc_array_conversion  import llc_compact_to_tiles
+from .llc_array_conversion  import llc_compact_to_faces
+from .llc_array_conversion  import llc_faces_to_tiles
+from .llc_array_conversion  import llc_faces_to_compact
+from .llc_array_conversion  import llc_tiles_to_faces
+from .llc_array_conversion  import llc_tiles_to_compact
 
 
-from mds_io import load_llc_compact
-from mds_io import load_llc_compact_to_faces
-from mds_io import load_llc_compact_to_tiles
-from tile_plot import plot_tiles
+from .mds_io import load_llc_compact
+from .mds_io import load_llc_compact_to_faces
+from .mds_io import load_llc_compact_to_tiles
+from .tile_plot import plot_tiles
 
 
 # Tests the mds_io and llc_array_conversion routines

--- a/ecco_v4_py/tile_plot_proj.py
+++ b/ecco_v4_py/tile_plot_proj.py
@@ -11,7 +11,7 @@ import matplotlib.pylab as plt
 import matplotlib.path as mpath
 import cartopy.crs as ccrs
 import cartopy.feature as cfeature
-import ecco_v4_py.resample_to_latlon as resample_to_latlon
+from .resample_to_latlon import resample_to_latlon
 
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%    
 def plot_proj_to_latlon_grid(lons, lats, data, 


### PR DESCRIPTION
This addresses #2 by replacing the current `read_binary_array` function with `xmitgcm.utils.read_3d_llc_data`. The main changes are:

- Rather than a binary being read in "compact" form, it is read in "tile" form
- Other functions then convert tile-> faces or compact

Note that binaries are now read in as dask arrays, and have the benefit of being only read into memory at computation time.

Additionally, this passes the test: `test_llc_array_loading_and_conversion` 

Some other less interesting changes are the names: I changed the names to say "read_bin" to indicate that this should only be used to read in binaries, because reading in meta/data pairs can and probably should be done with other methods, e.g. `xmitgcm.open_mdsdataset` or `MITgcmutils.rdmds`. 

Finally, note that `ecco_v4_py` and `xmitgcm` have different default array orders. 

`xmitgcm` reads in as [N_recs, N_z, N_tiles, N_y, N_x]
`ecco_v4_py` requires (for array conversion routines) [N_tiles, N_recs, N_z, N_y, N_x]

It might be worthwhile to eventually address this in a future (or maybe in this) PR. Let me know what you think. 