### PR TITLE
Convert numpy array to xarray

### DIFF
--- a/ecco_v4_py/__init__.py
+++ b/ecco_v4_py/__init__.py
@@ -14,13 +14,13 @@ from .llc_array_conversion  import llc_compact_to_faces
 from .llc_array_conversion  import llc_faces_to_tiles
 from .llc_array_conversion  import llc_tiles_to_faces
 from .llc_array_conversion  import llc_faces_to_compact
+from .llc_array_conversion  import llc_tiles_to_xda
 
 from .netcdf_product_generation import create_nc_grid_files_on_native_grid_from_mds
 from .netcdf_product_generation import get_time_steps_from_mds_files
 from .netcdf_product_generation import create_nc_variable_files_on_native_grid_from_mds
 from .netcdf_product_generation import update_ecco_dataset_geospatial_metadata
 from .netcdf_product_generation import update_ecco_dataset_temporal_coverage_metadata
-
 
 from .read_bin_llc import read_llc_to_tiles 
 from .read_bin_llc import read_llc_to_compact

--- a/ecco_v4_py/llc_array_conversion.py
+++ b/ecco_v4_py/llc_array_conversion.py
@@ -917,6 +917,6 @@ def _make_data_array(data_tiles, iVar, jVar, kVar, less_output=False):
 
     coords['tile'] = tile_da
     coords[jVar] = j_da
-    coords[jVar] = i_da
+    coords[iVar] = i_da
 
     return xr.DataArray(data=data_tiles, coords=coords, dims=dims)

--- a/ecco_v4_py/llc_array_conversion.py
+++ b/ecco_v4_py/llc_array_conversion.py
@@ -717,7 +717,7 @@ def llc_faces_to_compact(F, less_output=True):
     return data_compact
 
 #%%
-def llc_tiles_to_xda(data_tiles, var_type, grid_ds=None, less_output=False):
+def llc_tiles_to_xda(data_tiles, var_type=None, grid_da=None, less_output=False):
     """
     Convert numpy or dask array in tiled format to xarray DataArray 
     with minimal coordinates: (time,k,tile,j,i) ; (time,k,tile,j_g,i) etc...
@@ -738,13 +738,14 @@ def llc_tiles_to_xda(data_tiles, var_type, grid_ds=None, less_output=False):
     ----------
     data_tiles : numpy or dask+numpy array
         see above for specified dimension order
-    var_type : string
+    var_type : string, optional
+        Note: only optional if grid_da is provided! 
         specification for where on the grid the variable lives
         'c' - grid cell center, i.e. tracer point, e.g. XC, THETA, ...
         'w' - west grid cell edge, e.g. dxG, zonal velocity, ...
         's' - south grid cell edge, e.g. dyG, meridional velocity, ...
         'z' - southwest grid cell edge, zeta/vorticity point, e.g. rAz
-    grid_ds : xarray DataArray or Dataset, optional
+    grid_da : xarray DataArray, optional
         a DataArray or Dataset with the grid coordinates already loaded
     less_output : boolean, optional
         A debugging flag.  False = less debugging output
@@ -754,6 +755,9 @@ def llc_tiles_to_xda(data_tiles, var_type, grid_ds=None, less_output=False):
     -------
     da : xarray DataArray
     """
+
+    if var_type is None and grid_da is None:
+        raise TypeError('Must specify var_type="c","w","s", or "z" if grid_da is not provided')
 
     # Reshape data to match xmitgcm dimension order
     # Want it in [N_recs, N_z, N_tiles, N_j, N_i]
@@ -793,7 +797,7 @@ def llc_tiles_to_xda(data_tiles, var_type, grid_ds=None, less_output=False):
         raise TypeError('Found unfamiliar array shape: %d' % data_tiles.shape)
 
     # If a DataArray or Dataset is given to model after, use this first!
-    if grid_ds is not None:
+    if grid_da is not None:
         da = xr.DataArray(data=data_tiles,
                           coords=grid_da.coords.variables,
                           dims=grid_da.dims,

--- a/ecco_v4_py/llc_array_conversion.py
+++ b/ecco_v4_py/llc_array_conversion.py
@@ -863,6 +863,11 @@ def _make_data_array(data_tiles, iVar, jVar, kVar, less_output=False):
     fourthDimIsDepth = True
     if len(d_4) != 50:
         fourthDimIsDepth = False
+        if not less_output:
+            print('Assuming fourth dimension is time because len(data[-4]) != 50')
+    else:
+        if not less_output:
+            print('Assuming fourth dimension is depth because len(data[-4]) = 50')
 
     # We can't say much about tile or time dimension
     tile_attrs = OrderedDict([('standard_name','face_index')])

--- a/ecco_v4_py/llc_array_conversion.py
+++ b/ecco_v4_py/llc_array_conversion.py
@@ -759,7 +759,7 @@ def llc_tiles_to_xda(data_tiles, var_type=None, grid_da=None, less_output=False,
     dim3 : string, optional
         Specify the third dimension, either 'depth' or 'time'
     dim4 : string, optional
-        Specify the third dimension, either 'depth' or 'time'
+        Specify the fourth dimension, either 'depth' or 'time'
 
 
     Returns


### PR DESCRIPTION
This PR adds capability to convert a "tiled" numpy (or dask) array, for example read in via `read_bin_to_tiles`, to an xarray DataArray. 

See comments in the user facing function `llc_tiles_to_xda` for usage example. Need to add example usage documentation. 