### PR TITLE
projection plot reorganization and functionality

### DIFF
--- a/ecco_v4_py/tile_plot_proj.py
+++ b/ecco_v4_py/tile_plot_proj.py
@@ -48,6 +48,7 @@ def plot_proj_to_latlon_grid(lons, lats, data,
             'cyl' - Lambert Cylindrical
             'ortho' - Orthographic
             'stereo' - polar stereographic projection, see lat_lim for choosing
+            'InterruptedGoodeHomolosine'
                 North or South
     user_lon_0 : int, optional
         denote central longitude
@@ -79,8 +80,6 @@ def plot_proj_to_latlon_grid(lons, lats, data,
             cmax =  kwargs[key]
         else:
             print("unrecognized argument ", key)
-
-
 
     #%%
     # To avoid plotting problems around the date line, lon=180E, -180W 
@@ -303,26 +302,15 @@ def plot_global(xx,yy, data,
 
 def _create_projection_axis(projection_type,user_lon_0,lat_lim):
     """Set appropriate axis for projection type
-
-    Parameters
-    ----------
-    projection_type :   string
-                        user specified projection
-
-    user_lon_0      :   double
-                        center longitude value
-
-    lat_lim         :   double
-                        limiting latitude value
-
+    See plot_proj_to_latlon_grid for input parameter definitions.
 
     Returns
     -------
-    ax              :   matplotlib axis object
-
-    show_grid_labels:   logical
-                        True = show the grid labels, only currently
-                        supported for PlateCarree and Mercator projections
+    ax :  matplotlib axis object
+        defined with the correct projection
+    show_grid_labels : logical
+        True = show the grid labels, only currently
+        supported for PlateCarree and Mercator projections
     """
         
 
@@ -359,7 +347,7 @@ def _create_projection_axis(projection_type,user_lon_0,lat_lim):
         show_grid_labels = False
         
     else:
-        raise ValueError('projection type must be either "Mercator", "PlateCaree",  "cyl", "robin", "ortho", or "stereo"')
+        raise NotImplementedError('projection type must be either "Mercator", "PlateCaree",  "cyl", "robin", "ortho", "stereo", or "InterruptedGoodeHomolosine"')
 
     #print ('projection type ', projection_type)
     return (ax,show_grid_labels)

--- a/ecco_v4_py/tile_plot_proj.py
+++ b/ecco_v4_py/tile_plot_proj.py
@@ -32,6 +32,16 @@ def plot_proj_to_latlon_grid(lons, lats, data,
                              show_grid_lines = True,
                              show_grid_labels = True,
                              **kwargs):
+    """Generate a plot of llc data, resampled to lat/lon grid, on specified 
+    projection.
+
+    Parameters
+    ----------
+    lons    : 
+    lats    :
+    data    : 
+
+    """
     
     #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
     # default projection type = robinson
@@ -94,55 +104,15 @@ def plot_proj_to_latlon_grid(lons, lats, data,
         lon_tmp_d['B'] = [B_left_limit, B_right_limit]
 
     # Make projection axis
-    if projection_type == 'Mercator':
-        ax = plt.axes(projection =  ccrs.Mercator(central_longitude=user_lon_0))
-
-    elif projection_type == 'PlateCaree':
-        ax = plt.axes(projection = ccrs.PlateCarree(central_longitude=user_lon_0))
-
-    elif projection_type == 'cyl':
-        ax = plt.axes(projection = ccrs.LambertCylindrical(central_longitude=user_lon_0))
-        print ('Cannot label gridlines on a LambertCylindrical plot.  Only PlateCarree and Mercator plots are currently supported.')        
-        show_grid_labels = False
-
-    elif projection_type == 'robin':    
-        ax = plt.axes(projection = ccrs.Robinson(central_longitude=user_lon_0))
-        show_grid_labels=False
-        print ('Cannot label gridlines on a Robinson plot.  Only PlateCarree and Mercator plots are currently supported.')
-        show_grid_labels = False
-
-    elif projection_type == 'ortho':
-        ax = plt.axes(projection =  ccrs.Orthographic(central_longitude=user_lon_0))
-        print ('Cannot label gridlines on a Orthographic plot.  Only PlateCarree and Mercator plots are currently supported.')        
-        show_grid_labels = False
-
-    elif projection_type == 'stereo':    
-        if lat_lim > 0:
-            ax = plt.axes(projection =ccrs.NorthPolarStereo())
-        else:
-            ax = plt.axes(projection =ccrs.SouthPolarStereo())
-
-        print ('Cannot label gridlines on a polar stereographic plot.  Only PlateCarree and Mercator plots are currently supported.')            
-        show_grid_labels = False
-
-    elif projection_type == 'InterruptedGoodeHomolosine':
-        print ('Cannot label gridlines on a InterruptedGoodeHomolosine plot.  Only PlateCarree and Mercator plots are currently supported.')            
-        
-        ax = plt.axes(projection = ccrs.InterruptedGoodeHomolosine(central_longitude=user_lon_0))
-        show_grid_labels = False
-        
-    else:
-        raise ValueError('projection type must be either "Mercator", "PlateCaree",  "cyl", "robin", "ortho", or "stereo"')
-
-    print ('projection type ', projection_type)
+    (ax,show_grid_labels) = _create_projection_axis(
+            projection_type,user_lon_0,lat_lim)
     
 
     #%%
     # loop through different parts of the map to plot (if they exist), 
     # do interpolation and plot
     f = plt.gcf()
-    
-    print(len(lon_tmp_d))
+    #print(len(lon_tmp_d))
     for key, lon_tmp in lon_tmp_d.items():
 
         new_grid_lon, new_grid_lat, data_latlon_projection = \
@@ -314,3 +284,66 @@ def plot_global(xx,yy, data,
         cbar = plt.colorbar(sm,ax=ax)
     
     return p, gl, cbar
+
+# -----------------------------------------------------------------------------
+
+def _create_projection_axis(projection_type,user_lon_0,lat_lim):
+    """Set appropriate axis for projection type
+
+    Parameters
+    ----------
+    projection_type :   string
+                        user specified projection
+
+    user_lon_0      :   double
+                        center longitude value
+
+    lat_lim         :   double
+                        limiting latitude value
+
+
+    Returns
+    -------
+    ax              :   matplotlib axis object
+
+    show_grid_labels:   logical
+                        True = show the grid labels, only currently
+                        supported for PlateCarree and Mercator projections
+    """
+        
+
+    if projection_type == 'Mercator':
+        ax = plt.axes(projection =  ccrs.Mercator(central_longitude=user_lon_0))
+
+    elif projection_type == 'PlateCaree':
+        ax = plt.axes(projection = ccrs.PlateCarree(central_longitude=user_lon_0))
+
+    elif projection_type == 'cyl':
+        ax = plt.axes(projection = ccrs.LambertCylindrical(central_longitude=user_lon_0))
+        show_grid_labels = False
+
+    elif projection_type == 'robin':    
+        ax = plt.axes(projection = ccrs.Robinson(central_longitude=user_lon_0))
+        show_grid_labels = False
+
+    elif projection_type == 'ortho':
+        ax = plt.axes(projection =  ccrs.Orthographic(central_longitude=user_lon_0))
+        show_grid_labels = False
+
+    elif projection_type == 'stereo':    
+        if lat_lim > 0:
+            ax = plt.axes(projection =ccrs.NorthPolarStereo())
+        else:
+            ax = plt.axes(projection =ccrs.SouthPolarStereo())
+
+        show_grid_labels = False
+
+    elif projection_type == 'InterruptedGoodeHomolosine':
+        ax = plt.axes(projection = ccrs.InterruptedGoodeHomolosine(central_longitude=user_lon_0))
+        show_grid_labels = False
+        
+    else:
+        raise ValueError('projection type must be either "Mercator", "PlateCaree",  "cyl", "robin", "ortho", or "stereo"')
+
+    #print ('projection type ', projection_type)
+    return (ax,show_grid_labels)

--- a/ecco_v4_py/tile_plot_proj.py
+++ b/ecco_v4_py/tile_plot_proj.py
@@ -314,9 +314,11 @@ def _create_projection_axis(projection_type,user_lon_0,lat_lim):
 
     if projection_type == 'Mercator':
         ax = plt.axes(projection =  ccrs.Mercator(central_longitude=user_lon_0))
+        show_grid_labels = True
 
     elif projection_type == 'PlateCaree':
         ax = plt.axes(projection = ccrs.PlateCarree(central_longitude=user_lon_0))
+        show_grid_labels = True
 
     elif projection_type == 'cyl':
         ax = plt.axes(projection = ccrs.LambertCylindrical(central_longitude=user_lon_0))

--- a/ecco_v4_py/tile_plot_proj.py
+++ b/ecco_v4_py/tile_plot_proj.py
@@ -31,6 +31,7 @@ def plot_proj_to_latlon_grid(lons, lats, data,
                              show_colorbar = False, 
                              show_grid_lines = True,
                              show_grid_labels = True,
+                             less_output=True,
                              **kwargs):
     """Generate a plot of llc data, resampled to lat/lon grid, on specified 
     projection.
@@ -42,7 +43,7 @@ def plot_proj_to_latlon_grid(lons, lats, data,
         be plotted
     projection_type : string, optional
         denote the type of projection, options include
-            'robin' - Robinson 
+            'robin' - Robinson
             'PlateCaree' - flat 2D projection
             'Mercator'
             'cyl' - Lambert Cylindrical
@@ -67,6 +68,8 @@ def plot_proj_to_latlon_grid(lons, lats, data,
         True only possible for Mercator or PlateCarree projections
     cmin, cmax : float, optional
         minimum and maximum values for colorbar, default is min/max of data
+    less_output : string, optional
+        debugging flag, don't print if True
     """
 
     #%%    
@@ -118,14 +121,15 @@ def plot_proj_to_latlon_grid(lons, lats, data,
 
     # Make projection axis
     (ax,show_grid_labels) = _create_projection_axis(
-            projection_type,user_lon_0,lat_lim)
+            projection_type,user_lon_0,lat_lim,less_output)
     
 
     #%%
     # loop through different parts of the map to plot (if they exist), 
     # do interpolation and plot
     f = plt.gcf()
-    #print(len(lon_tmp_d))
+    if not less_output:
+        print('len(lon_tmp_d): ',len(lon_tmp_d))
     for key, lon_tmp in lon_tmp_d.items():
 
         new_grid_lon, new_grid_lat, data_latlon_projection = \
@@ -146,7 +150,8 @@ def plot_proj_to_latlon_grid(lons, lats, data,
                              show_colorbar=False, 
                              circle_boundary=True,
                              cmap=cmap, 
-                             show_grid_lines=False)
+                             show_grid_lines=False,
+                             less_output=less_output)
 
         else: # not polar stereo
             p, gl, cbar = \
@@ -194,19 +199,23 @@ def plot_pstereo(xx,yy, data,
                  circle_boundary = False, 
                  cmap='jet', 
                  show_grid_lines=False,
-                 levels = 20):
+                 levels = 20,
+                 less_output=True):
 
                             
     if isinstance(ax.projection, ccrs.NorthPolarStereo):
         ax.set_extent([-180, 180, lat_lim, 90], ccrs.PlateCarree())
-        print('north')
+        if not less_output:
+            print('North Polar Projection')
     elif isinstance(ax.projection, ccrs.SouthPolarStereo):
         ax.set_extent([-180, 180, -90, lat_lim], ccrs.PlateCarree())
-        print('south')
+        if not less_output:
+            print('South Polar Projection')
     else:
         raise ValueError('ax must be either ccrs.NorthPolarStereo or ccrs.SouthPolarStereo')
 
-    print(lat_lim)
+    if not less_output:
+        print('lat_lim: ',lat_lim)
     
     if circle_boundary:
         theta = np.linspace(0, 2*np.pi, 100)
@@ -300,7 +309,7 @@ def plot_global(xx,yy, data,
 
 # -----------------------------------------------------------------------------
 
-def _create_projection_axis(projection_type,user_lon_0,lat_lim):
+def _create_projection_axis(projection_type,user_lon_0,lat_lim,less_output):
     """Set appropriate axis for projection type
     See plot_proj_to_latlon_grid for input parameter definitions.
 
@@ -349,5 +358,7 @@ def _create_projection_axis(projection_type,user_lon_0,lat_lim):
     else:
         raise NotImplementedError('projection type must be either "Mercator", "PlateCaree",  "cyl", "robin", "ortho", "stereo", or "InterruptedGoodeHomolosine"')
 
-    #print ('projection type ', projection_type)
+    if not less_output:
+        print('Projection type: ', projection_type)
+
     return (ax,show_grid_labels)

--- a/ecco_v4_py/tile_plot_proj.py
+++ b/ecco_v4_py/tile_plot_proj.py
@@ -37,22 +37,36 @@ def plot_proj_to_latlon_grid(lons, lats, data,
 
     Parameters
     ----------
-    lons    : 
-    lats    :
-    data    : 
+    lons, lats, data : xarray DataArray    : 
+        give the longitude, latitude values of the grid, and the 2D field to 
+        be plotted
+    projection_type : string, optional
+        denote the type of projection, options include
+            'robin' - Robinson 
+            'PlateCaree' - flat 2D projection
+            'Mercator'
+            'cyl' - Lambert Cylindrical
+            'ortho' - Orthographic
+            'stereo' - polar stereographic projection, see lat_lim for choosing
+                North or South
+    user_lon_0 : int, optional
+        denote central longitude
+    lat_lim : int, optional
+        for stereographic projection, denote the Southern (Northern) bounds for 
+        North (South) polar projection
+    levels : int, optional
+        number of contours to plot
+    cmap : string or colormap object, optional
+        denotes to colormap
+    dx, dy : float, optional
+        latitude, longitude spacing for grid resampling
+    show_colorbar : logical, optional
 
+    show_grid_lines : logical, optional
+        True only possible for Mercator or PlateCarree projections
+    cmin, cmax : float, optional
+        minimum and maximum values for colorbar, default is min/max of data
     """
-    
-    #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-    # default projection type = robinson
-    # default central longitude = 60W
-    # default no colorbar, no grid labels, no grid lines.
-    # default color limits take the min and max of the values
-    # default plot_type is pcolormesh.
-    # default lat/lon spacing in lat/lon grid is 0.25 degrees
-    # default number of levels for contourf is 20 (levels)
-    # default latitude limit for polar stereographic plots is 50N (lat_lim)
-    # default colormap is 'jet'
 
     #%%    
     cmin = np.nanmin(data)

--- a/ecco_v4_py/tile_plot_proj.py
+++ b/ecco_v4_py/tile_plot_proj.py
@@ -31,6 +31,7 @@ def plot_proj_to_latlon_grid(lons, lats, data,
                              show_colorbar = False, 
                              show_grid_lines = True,
                              show_grid_labels = True,
+                             subplot_grid=None,
                              less_output=True,
                              **kwargs):
     """Generate a plot of llc data, resampled to lat/lon grid, on specified 
@@ -68,6 +69,18 @@ def plot_proj_to_latlon_grid(lons, lats, data,
         True only possible for Mercator or PlateCarree projections
     cmin, cmax : float, optional
         minimum and maximum values for colorbar, default is min/max of data
+    subplot_grid : dict or list, optional
+        specifying placement on subplot as
+            dict:
+                {'nrows': rows_val, 'ncols': cols_val, 'index': index_val}
+
+            list:
+                [nrows_val, ncols_val, index_val]
+
+            equates to
+
+                matplotlib.pyplot.subplot(
+                    row=nrows_val, col=ncols_val,index=index_val)
     less_output : string, optional
         debugging flag, don't print if True
     """
@@ -121,7 +134,7 @@ def plot_proj_to_latlon_grid(lons, lats, data,
 
     # Make projection axis
     (ax,show_grid_labels) = _create_projection_axis(
-            projection_type,user_lon_0,lat_lim,less_output)
+            projection_type, user_lon_0, lat_lim, subplot_grid, less_output)
     
 
     #%%
@@ -309,7 +322,8 @@ def plot_global(xx,yy, data,
 
 # -----------------------------------------------------------------------------
 
-def _create_projection_axis(projection_type,user_lon_0,lat_lim,less_output):
+def _create_projection_axis(projection_type, user_lon_0, lat_lim, subplot_grid,
+                            less_output):
     """Set appropriate axis for projection type
     See plot_proj_to_latlon_grid for input parameter definitions.
 
@@ -321,38 +335,88 @@ def _create_projection_axis(projection_type,user_lon_0,lat_lim,less_output):
         True = show the grid labels, only currently
         supported for PlateCarree and Mercator projections
     """
-        
+
+    # initialize (optional) subplot variables
+    row = []
+    col = []
+    ind = []
+
+    if subplot_grid is not None:
+
+        if type(subplot_grid) is dict:
+            row = subplot_grid['nrows']
+            col = subplot_grid['ncols']
+            ind = subplot_grid['index']
+
+        elif type(subplot_grid) is list:
+            row = subplot_grid[0]
+            col = subplot_grid[1]
+            ind = subplot_grid[2]
+
+        else:
+            raise TypeError('Unexpected subplot_grid type: ',type(subplot_grid))
+
 
     if projection_type == 'Mercator':
-        ax = plt.axes(projection =  ccrs.Mercator(central_longitude=user_lon_0))
+        if subplot_grid is not None:
+            ax = plt.subplot(row, col, ind,
+                    projection=ccrs.Mercator(central_longitude=user_lon_0))
+        else:
+            ax = plt.axes(projection=ccrs.Mercator(central_longitude=user_lon_0))
         show_grid_labels = True
 
     elif projection_type == 'PlateCaree':
-        ax = plt.axes(projection = ccrs.PlateCarree(central_longitude=user_lon_0))
+        if subplot_grid is not None:
+            ax = plt.subplot(row, col, ind,
+                    projection=ccrs.PlateCarree(central_longitude=user_lon_0))
+        else:
+            ax = plt.axes(projection=ccrs.PlateCarree(central_longitude=user_lon_0))
         show_grid_labels = True
 
     elif projection_type == 'cyl':
-        ax = plt.axes(projection = ccrs.LambertCylindrical(central_longitude=user_lon_0))
+        if subplot_grid is not None:
+            ax = plt.subplot(row, col, ind,
+                    projection=ccrs.LambertCylindrical(central_longitude=user_lon_0))
+        else:
+            ax = plt.axes(projection=ccrs.LambertCylindrical(central_longitude=user_lon_0))
         show_grid_labels = False
 
     elif projection_type == 'robin':    
-        ax = plt.axes(projection = ccrs.Robinson(central_longitude=user_lon_0))
+        if subplot_grid is not None:
+            ax = plt.subplot(row, col, ind,
+                    projection=ccrs.Robinson(central_longitude=user_lon_0))
+        else:
+            ax = plt.axes(projection=ccrs.Robinson(central_longitude=user_lon_0))
         show_grid_labels = False
 
     elif projection_type == 'ortho':
-        ax = plt.axes(projection =  ccrs.Orthographic(central_longitude=user_lon_0))
+        if subplot_grid is not None:
+            ax = plt.subplot(row, col, ind,
+                    projection=ccrs.Orthographic(central_longitude=user_lon_0))
+        else:
+            ax = plt.axes(projection=ccrs.Orthographic(central_longitude=user_lon_0))
         show_grid_labels = False
 
     elif projection_type == 'stereo':    
         if lat_lim > 0:
-            ax = plt.axes(projection =ccrs.NorthPolarStereo())
+            stereo_proj = ccrs.NorthPolarStereo()
         else:
-            ax = plt.axes(projection =ccrs.SouthPolarStereo())
+            stereo_proj = ccrs.SouthPolarStereo()
+
+        if subplot_grid is not None:
+            ax = plt.subplot(row, col, ind,
+                    projection=stereo_proj)
+        else:
+            ax = plt.axes(projection=stereo_proj)
 
         show_grid_labels = False
 
     elif projection_type == 'InterruptedGoodeHomolosine':
-        ax = plt.axes(projection = ccrs.InterruptedGoodeHomolosine(central_longitude=user_lon_0))
+        if subplot_grid is not None:
+            ax = plt.subplot(row, col, ind,
+                    projection=ccrs.InterruptedGoodeHomolosine(central_longitude=user_lon_0))
+        else:
+            ax = plt.axes(projection=ccrs.InterruptedGoodeHomolosine(central_longitude=user_lon_0))
         show_grid_labels = False
         
     else:


### PR DESCRIPTION
This PR adds to the function `plot_proj_to_latlon_grid`:
- ability to create subplots with "projection plots" via the subplot_grid option
- a less_output flag for reducing print statements

Reorganization:
- There is now a separate function for establishing the projection type since this became quite messy with handling the subplot grid argument.

Also I reformatted the comments to show up nicely in the API documentation. 