### PR TITLE
absolute paths for module imports

### DIFF
--- a/ecco_v4_py/__init__.py
+++ b/ecco_v4_py/__init__.py
@@ -47,7 +47,7 @@ from .read_bin_gen import load_binary_array
 
 from .resample_to_latlon import resample_to_latlon
 
-import scalar_calc
+from ecco_v4_py import  scalar_calc
 
 from .tile_exchange import append_border_to_tile
 from .tile_exchange import add_borders_to_DataArray_V_points
@@ -82,7 +82,7 @@ from .tile_rotation import rotate_single_tile_DataArrays_UV_points
 
 from .test_llc_array_loading_and_conversion import run_read_bin_and_llc_conversion_test
 
-import vector_calc
+from ecco_v4_py import vector_calc
 
 __all__ = ['calc_meridional_trsp',
            'calc_section_trsp',

--- a/ecco_v4_py/calc_meridional_trsp.py
+++ b/ecco_v4_py/calc_meridional_trsp.py
@@ -12,7 +12,7 @@ except ImportError:
 
 from .get_basin import get_basin_mask
 from .ecco_utils import get_llc_grid
-from .vector_calc import get_latitude_masks
+from ecco_v4_py import vector_calc
 
 # Define constants
 # These are chosen (for now) to match gcmfaces
@@ -191,7 +191,7 @@ def meridional_trsp_at_depth(xfld, yfld, lat_vals, cds,
     for lat in lat_vals:
 
         # Compute mask for particular latitude band
-        lat_maskW, lat_maskS = get_latitude_masks(lat, cds['YC'], grid)
+        lat_maskW, lat_maskS = vector_calc.get_latitude_masks(lat, cds['YC'], grid)
 
         # Sum horizontally
         lat_trsp_x = (xfld * lat_maskW * basin_maskW).sum(dim=['i_g','j','tile'])

--- a/ecco_v4_py/get_section_masks.py
+++ b/ecco_v4_py/get_section_masks.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from .ecco_utils import get_llc_grid
 from .llc_array_conversion import llc_tiles_to_xda
-from . import scalar_calc
+from ecco_v4_py import scalar_calc
 
 # -------------------------------------------------------------------------------
 # Functions for generating pre-defined section masks


### PR DESCRIPTION
Change import statements for vector_calc and scalar_calc from
`from . import scalar_calc` or `import scalar_calc`

(former does not work for @ifenty, latter does not work for me)

to 

`from ecco_v4_py import scalar_calc` 

Same modifications made to functions which use the same statements. 
@ifenty - this is great motivation for us to eventually write some tests ... I think after the school would be a great time. For now though, what is your setup? What version of python do you run? 

