### PR TITLE
Trsp as dataset

### DIFF
--- a/ecco_v4_py/calc_meridional_trsp.py
+++ b/ecco_v4_py/calc_meridional_trsp.py
@@ -41,29 +41,40 @@ def calc_meridional_vol_trsp(ds,lat_vals,basin_name=None,grid=None):
 
     Returns
     -------
-    vol_trsp : xarray DataArray
-        meridional freshwater transport in Sv
-        with dimensions 'time' (if in given dataset) and 'lat' 
+    ds_out : xarray Dataset
+        Dataset with the following variables
+            'vol_trsp' :
+                meridional volume transport in Sv
+                with dimensions 'time' (if in given dataset) and 'lat'
+            'vol_trsp_z' :
+                meridional volume transport in Sv at each depth level
+                in the given input fields
+                dimensions: 'time' (if provided), 'lat', and 'k'
     """
 
     x_vol = ds['UVELMASS'] * ds['drF'] * ds['dyG']
     y_vol = ds['VVELMASS'] * ds['drF'] * ds['dxG']
 
     # Computes salt transport in m^3/s at each depth level
-    vol_trsp = meridional_trsp_at_depth(x_vol,y_vol,
+    vol_trsp_z = meridional_trsp_at_depth(x_vol,y_vol,
                                        cds=ds.coords.to_dataset(),
                                        lat_vals=lat_vals,
                                        basin_name=basin_name,
                                        grid=grid)
 
-    # Sum over depth
-    vol_trsp = vol_trsp.sum('k')
+    # Make a datset with this result
+    ds_out = vol_trsp.to_dataset(name='vol_trsp_z')
 
-    # Convert to Sv
-    vol_trsp = METERS_CUBED_TO_SVERDRUPS * vol_trsp
-    vol_trsp.attrs['units'] = 'Sv'
+    # Sum over depth for total transport
+    ds_out['vol_trsp'] = ds_out['vol_trsp_z'].sum('k')
 
-    return vol_trsp
+
+    # Convert both fields to Sv
+    for fld in ['vol_trsp','vol_trsp_z']:
+        ds_out[fld] = METERS_CUBED_TO_SVERDRUPS * ds_out[fld]
+        ds_out[fld].attrs['units'] = 'Sv'
+
+    return ds_out
 
 
 def calc_meridional_heat_trsp(ds,lat_vals,basin_name=None,grid=None):
@@ -78,9 +89,15 @@ def calc_meridional_heat_trsp(ds,lat_vals,basin_name=None,grid=None):
 
     Returns
     -------
-    heat_trsp : xarray DataArray
-        meridional heat transport in petawatts
-        with dimensions 'time' (if in given dataset) and 'lat' 
+    ds_out : xarray Dataset
+        Dataset with the following variables
+            'heat_trsp' :
+                meridional heat transport in PW
+                with dimensions 'time' (if in given dataset) and 'lat'
+            'heat_trsp_z' :
+                meridional heat transport in PW at each depth level
+                in the given input fields
+                dimensions: 'time' (if provided), 'lat', and 'k'
     """
 
     x_heat = ds['ADVx_TH'] + ds['DFxE_TH']
@@ -93,15 +110,18 @@ def calc_meridional_heat_trsp(ds,lat_vals,basin_name=None,grid=None):
                                          basin_name=basin_name,
                                          grid=grid)
 
-    # Sum over depth
-    heat_trsp = heat_trsp.sum('k')
+    # Make a datset with this result
+    ds_out = heat_trsp.to_dataset(name='heat_trsp_z')
 
-    # Convert to PetaWatts
-    heat_trsp = WATTS_TO_PETAWATTS * RHO_CONST * HEAT_CAPACITY * heat_trsp
+    # Sum over depth for total transport
+    ds_out['heat_trsp'] = ds_out['heat_trsp_z'].sum('k')
 
-    heat_trsp.attrs['units'] = 'PW'
+    # Convert both fields to Sv
+    for fld in ['heat_trsp','heat_trsp_z']:
+        ds_out[fld] = WATTS_TO_PETAWATTS * RHO_CONST * HEAT_CAPACITY * ds_out[fld]
+        ds_out[fld].attrs['units'] = 'PW'
 
-    return heat_trsp
+    return ds_out
 
 def calc_meridional_salt_trsp(ds,lat_vals,basin_name=None,grid=None):
     """Compute salt transport across latitude band in psu * Sv
@@ -115,9 +135,15 @@ def calc_meridional_salt_trsp(ds,lat_vals,basin_name=None,grid=None):
 
     Returns
     -------
-    salt_trsp : xarray DataArray
-        meridional salt transport in psu*Sv
-        with dimensions 'time' (if in given dataset) and 'lat' 
+    ds_out : xarray Dataset
+        Dataset with the following variables
+            'salt_trsp' :
+                meridional salt transport in psu*Sv
+                with dimensions 'time' (if in given dataset) and 'lat'
+            'salt_trsp_z' :
+                meridional salt transport in psu*Sv at each depth level
+                in the given input fields
+                dimensions: 'time' (if provided), 'lat', and 'k'
     """
 
     x_salt = ds['ADVx_SLT'] + ds['DFxE_SLT']
@@ -129,15 +155,18 @@ def calc_meridional_salt_trsp(ds,lat_vals,basin_name=None,grid=None):
                                          lat_vals=lat_vals,
                                          basin_name=basin_name,
                                          grid=grid)
-    # Sum over depth
-    salt_trsp = salt_trsp.sum('k')
+    # Make a datset with this result
+    ds_out = salt_trsp.to_dataset(name='salt_trsp_z')
 
-    # Convert to psu * Sv
-    salt_trsp = METERS_CUBED_TO_SVERDRUPS * salt_trsp
-    salt_trsp.attrs['units'] = 'psu.Sv'
+    # Sum over depth for total transport
+    ds_out['salt_trsp'] = ds_out['salt_trsp_z'].sum('k')
 
-    return salt_trsp
+    # Convert both fields to psu.Sv
+    for fld in ['salt_trsp','salt_trsp_z']:
+        ds_out[fld] = METERS_CUBED_TO_SVERDRUPS * ds_out[fld]
+        ds_out[fld].attrs['units'] = 'psu.Sv'
 
+    return ds_out
 
 # ---------------------------------------------------------------------
 

--- a/ecco_v4_py/calc_meridional_trsp.py
+++ b/ecco_v4_py/calc_meridional_trsp.py
@@ -57,13 +57,13 @@ def calc_meridional_vol_trsp(ds,lat_vals,basin_name=None,grid=None):
 
     # Computes salt transport in m^3/s at each depth level
     vol_trsp_z = meridional_trsp_at_depth(x_vol,y_vol,
-                                       cds=ds.coords.to_dataset(),
-                                       lat_vals=lat_vals,
-                                       basin_name=basin_name,
-                                       grid=grid)
+                                          cds=ds.coords.to_dataset(),
+                                          lat_vals=lat_vals,
+                                          basin_name=basin_name,
+                                          grid=grid)
 
     # Make a datset with this result
-    ds_out = vol_trsp.to_dataset(name='vol_trsp_z')
+    ds_out = vol_trsp_z.to_dataset(name='vol_trsp_z')
 
     # Sum over depth for total transport
     ds_out['vol_trsp'] = ds_out['vol_trsp_z'].sum('k')
@@ -104,14 +104,14 @@ def calc_meridional_heat_trsp(ds,lat_vals,basin_name=None,grid=None):
     y_heat = ds['ADVy_TH'] + ds['DFyE_TH']
 
     # Computes heat transport in degC * m^3/s at each depth level
-    heat_trsp = meridional_trsp_at_depth(x_heat,y_heat,
-                                         cds=ds.coords.to_dataset(),
-                                         lat_vals=lat_vals,
-                                         basin_name=basin_name,
-                                         grid=grid)
+    heat_trsp_z = meridional_trsp_at_depth(x_heat,y_heat,
+                                           cds=ds.coords.to_dataset(),
+                                           lat_vals=lat_vals,
+                                           basin_name=basin_name,
+                                           grid=grid)
 
     # Make a datset with this result
-    ds_out = heat_trsp.to_dataset(name='heat_trsp_z')
+    ds_out = heat_trsp_z.to_dataset(name='heat_trsp_z')
 
     # Sum over depth for total transport
     ds_out['heat_trsp'] = ds_out['heat_trsp_z'].sum('k')
@@ -150,13 +150,13 @@ def calc_meridional_salt_trsp(ds,lat_vals,basin_name=None,grid=None):
     y_salt = ds['ADVy_SLT'] + ds['DFyE_SLT']
 
     # Computes salt transport in psu * m^3/s at each depth level
-    salt_trsp = meridional_trsp_at_depth(x_salt,y_salt,
-                                         cds=ds.coords.to_dataset(),
-                                         lat_vals=lat_vals,
-                                         basin_name=basin_name,
-                                         grid=grid)
+    salt_trsp_z = meridional_trsp_at_depth(x_salt,y_salt,
+                                           cds=ds.coords.to_dataset(),
+                                           lat_vals=lat_vals,
+                                           basin_name=basin_name,
+                                           grid=grid)
     # Make a datset with this result
-    ds_out = salt_trsp.to_dataset(name='salt_trsp_z')
+    ds_out = salt_trsp_z.to_dataset(name='salt_trsp_z')
 
     # Sum over depth for total transport
     ds_out['salt_trsp'] = ds_out['salt_trsp_z'].sum('k')

--- a/ecco_v4_py/calc_meridional_trsp.py
+++ b/ecco_v4_py/calc_meridional_trsp.py
@@ -68,7 +68,6 @@ def calc_meridional_vol_trsp(ds,lat_vals,basin_name=None,grid=None):
     # Sum over depth for total transport
     ds_out['vol_trsp'] = ds_out['vol_trsp_z'].sum('k')
 
-
     # Convert both fields to Sv
     for fld in ['vol_trsp','vol_trsp_z']:
         ds_out[fld] = METERS_CUBED_TO_SVERDRUPS * ds_out[fld]
@@ -116,7 +115,7 @@ def calc_meridional_heat_trsp(ds,lat_vals,basin_name=None,grid=None):
     # Sum over depth for total transport
     ds_out['heat_trsp'] = ds_out['heat_trsp_z'].sum('k')
 
-    # Convert both fields to Sv
+    # Convert both fields to PW
     for fld in ['heat_trsp','heat_trsp_z']:
         ds_out[fld] = WATTS_TO_PETAWATTS * RHO_CONST * HEAT_CAPACITY * ds_out[fld]
         ds_out[fld].attrs['units'] = 'PW'

--- a/ecco_v4_py/calc_meridional_trsp.py
+++ b/ecco_v4_py/calc_meridional_trsp.py
@@ -56,11 +56,11 @@ def calc_meridional_vol_trsp(ds,lat_vals,basin_name=None,grid=None):
     y_vol = ds['VVELMASS'] * ds['drF'] * ds['dxG']
 
     # Computes salt transport in m^3/s at each depth level
-    vol_trsp_z = meridional_trsp_at_depth(x_vol,y_vol,
-                                          cds=ds.coords.to_dataset(),
-                                          lat_vals=lat_vals,
-                                          basin_name=basin_name,
-                                          grid=grid)
+    ds_out = meridional_trsp_at_depth(x_vol,y_vol,
+                                      cds=ds.coords.to_dataset(),
+                                      lat_vals=lat_vals,
+                                      basin_name=basin_name,
+                                      grid=grid)
 
     # Rename to useful data array name
     ds_out = ds_out.rename({'trsp_z': 'vol_trsp_z'})
@@ -104,10 +104,10 @@ def calc_meridional_heat_trsp(ds,lat_vals,basin_name=None,grid=None):
 
     # Computes heat transport in degC * m^3/s at each depth level
     ds_out = meridional_trsp_at_depth(x_heat,y_heat,
-                                           cds=ds.coords.to_dataset(),
-                                           lat_vals=lat_vals,
-                                           basin_name=basin_name,
-                                           grid=grid)
+                                      cds=ds.coords.to_dataset(),
+                                      lat_vals=lat_vals,
+                                      basin_name=basin_name,
+                                      grid=grid)
 
     # Rename to useful data array name
     ds_out = ds_out.rename({'trsp_z': 'heat_trsp_z'})
@@ -149,11 +149,11 @@ def calc_meridional_salt_trsp(ds,lat_vals,basin_name=None,grid=None):
     y_salt = ds['ADVy_SLT'] + ds['DFyE_SLT']
 
     # Computes salt transport in psu * m^3/s at each depth level
-    salt_trsp_z = meridional_trsp_at_depth(x_salt,y_salt,
-                                           cds=ds.coords.to_dataset(),
-                                           lat_vals=lat_vals,
-                                           basin_name=basin_name,
-                                           grid=grid)
+    ds_out = meridional_trsp_at_depth(x_salt,y_salt,
+                                      cds=ds.coords.to_dataset(),
+                                      lat_vals=lat_vals,
+                                      basin_name=basin_name,
+                                      grid=grid)
 
     # Rename to useful data array name
     ds_out = ds_out.rename({'trsp_z': 'salt_trsp_z'})

--- a/ecco_v4_py/calc_section_trsp.py
+++ b/ecco_v4_py/calc_section_trsp.py
@@ -74,11 +74,14 @@ def calc_section_vol_trsp(ds,
 
     Returns
     -------
-    vol_trsp_ds : xarray Dataset
+    ds_out : xarray Dataset
         includes variables as xarray DataArrays
             vol_trsp
                 freshwater transport across section in Sv
                 with dimensions 'time' (if in given dataset) and 'lat' 
+            vol_trsp_z
+                freshwater transport across section at each depth level in Sv
+                with dimensions 'time' (if in given dataset), 'lat', and 'k'
             maskW, maskS
                 defining the section
         and the section_name as an attribute if it is provided
@@ -91,26 +94,28 @@ def calc_section_vol_trsp(ds,
     y_vol = ds['VVELMASS'] * ds['drF'] * ds['dxG'] 
 
     # Computes salt transport in m^3/s at each depth level
-    vol_trsp = section_trsp_at_depth(x_vol,y_vol,maskW,maskS,
-                                     cds=ds.coords.to_dataset(),
-                                     grid=grid)
-    # Sum over depth
-    vol_trsp = vol_trsp.sum('k')
+    vol_trsp_z = section_trsp_at_depth(x_vol,y_vol,maskW,maskS,
+                                       cds=ds.coords.to_dataset(),
+                                       grid=grid)
 
-    # Convert to Sv
-    vol_trsp = METERS_CUBED_TO_SVERDRUPS * vol_trsp
-    vol_trsp.attrs['units'] = 'Sv'
+    # Make a datset with this result
+    ds_out = vol_trsp_z.to_dataset(name='vol_trsp_z')
 
-    # Add this to a Dataset
-    vol_trsp_ds = vol_trsp.to_dataset(name='vol_trsp')
+    # Sum over depth for total transport
+    ds_out['vol_trsp'] = ds_out['vol_trsp_z'].sum('k')
+
+    # Convert both fields to Sv
+    for fld in ['vol_trsp','vol_trsp_z']:
+        ds_out[fld] = METERS_CUBED_TO_SVERDRUPS * ds_out[fld]
+        ds_out[fld].attrs['units'] = 'Sv'
 
     # Add section name and masks to Dataset
-    vol_trsp_ds['maskW'] = maskW
-    vol_trsp_ds['maskS'] = maskS
+    ds_out['maskW'] = maskW
+    ds_out['maskS'] = maskS
     if section_name is not None:
-        vol_trsp_ds.attrs['name'] = section_name
+        ds_out.attrs['name'] = section_name
 
-    return vol_trsp_ds
+    return ds_out
 
 def calc_section_heat_trsp(ds,
                            pt1=None, pt2=None,
@@ -133,6 +138,9 @@ def calc_section_heat_trsp(ds,
             heat_trsp
                 heat transport across section in PW
                 with dimensions 'time' (if in given dataset) and 'lat' 
+            heat_trsp_z
+                heat transport across section at each depth level in PW
+                with dimensions 'time' (if in given dataset), 'lat', and 'k'
             maskW, maskS
                 defining the section
         and the section_name as an attribute if it is provided
@@ -145,26 +153,28 @@ def calc_section_heat_trsp(ds,
     y_heat = ds['ADVy_TH'] * ds['DFyE_TH']
 
     # Computes salt transport in degC * m^3/s at each depth level
-    heat_trsp = section_trsp_at_depth(x_heat,y_heat,maskW,maskS,
-                                      cds=ds.coords.to_dataset(),
-                                      grid=grid)
-    # Sum over depth
-    heat_trsp = heat_trsp.sum('k')
+    heat_trsp_z = section_trsp_at_depth(x_heat,y_heat,maskW,maskS,
+                                        cds=ds.coords.to_dataset(),
+                                        grid=grid)
 
-    # Convert to PW
-    heat_trsp = WATTS_TO_PETAWATTS * RHO_CONST * HEAT_CAPACITY * heat_trsp
-    heat_trsp.attrs['units'] = 'PW'
+    # Make a datset with this result
+    ds_out = heat_trsp_z.to_dataset(name='heat_trsp_z')
 
-    # Add this to a Dataset
-    heat_trsp_ds = heat_trsp.to_dataset(name='heat_trsp')
+    # Sum over depth for total transport
+    ds_out['heat_trsp'] = ds_out['heat_trsp_z'].sum('k')
+
+    # Convert both fields to PW
+    for fld in ['heat_trsp','heat_trsp_z']:
+        ds_out[fld] = WATTS_TO_PETAWATTS * RHO_CONST * HEAT_CAPACITY * ds_out[fld]
+        ds_out[fld].attrs['units'] = 'PW'
 
     # Add section name and masks to Dataset
-    heat_trsp_ds['maskW'] = maskW
-    heat_trsp_ds['maskS'] = maskS
+    ds_out['maskW'] = maskW
+    ds_out['maskS'] = maskS
     if section_name is not None:
-        heat_trsp_ds.attrs['name'] = section_name
+        ds_out.attrs['name'] = section_name
 
-    return heat_trsp_ds
+    return ds_out
 
 def calc_section_salt_trsp(ds,
                            pt1=None, pt2=None,
@@ -187,6 +197,9 @@ def calc_section_salt_trsp(ds,
             salt_trsp
                 salt transport across section in psu*Sv
                 with dimensions 'time' (if in given dataset) and 'lat' 
+            salt_trsp_z
+                salt transport across section at each depth level in psu*Sv
+                with dimensions 'time' (if in given dataset), 'lat', and 'k'
             maskW, maskS
                 defining the section
         and the section_name as an attribute if it is provided
@@ -199,26 +212,28 @@ def calc_section_salt_trsp(ds,
     y_salt = ds['ADVy_SLT'] * ds['DFyE_SLT']
 
     # Computes salt transport in psu * m^3/s at each depth level
-    salt_trsp = section_trsp_at_depth(x_salt,y_salt,maskW,maskS,
-                                      cds=ds.coords.to_dataset(),
-                                      grid=grid)
-    # Sum over depth
-    salt_trsp = salt_trsp.sum('k')
+    salt_trsp_z = section_trsp_at_depth(x_salt,y_salt,maskW,maskS,
+                                        cds=ds.coords.to_dataset(),
+                                        grid=grid)
 
-    # Convert to PW
-    salt_trsp = METERS_CUBED_TO_SVERDRUPS * salt_trsp
-    salt_trsp.attrs['units'] = 'psu.Sv'
+    # Make a datset with this result
+    ds_out = salt_trsp_z.to_dataset(name='salt_trsp_z')
 
-    # Add this to a Dataset
-    salt_trsp_ds = salt_trsp.to_dataset(name='salt_trsp')
+    # Sum over depth for total transport
+    ds_out['salt_trsp'] = ds_out['salt_trsp_z'].sum('k')
+
+    # Convert both fields to psu.Sv
+    for fld in ['salt_trsp','salt_trsp_z']:
+        ds_out[fld] = METERS_CUBED_TO_SVERDRUPS * ds_out[fld]
+        ds_out[fld].attrs['units'] = 'psu.Sv'
 
     # Add section name and masks to Dataset
-    salt_trsp_ds['maskW'] = maskW
-    salt_trsp_ds['maskS'] = maskS
+    ds_out['maskW'] = maskW
+    ds_out['maskS'] = maskS
     if section_name is not None:
-        salt_trsp_ds.attrs['name'] = section_name
+        ds_out.attrs['name'] = section_name
 
-    return salt_trsp_ds
+    return ds_out
 
 # -------------------------------------------------------------------------------
 # Main function for computing standard transport quantities


### PR DESCRIPTION
This changes some subroutines in the `calc_meridional_trsp` and `calc_section_trsp` modules so that all of the volume, heat, and salt transport functions return a dataset which has the transport at each depth level as well as the vertical sum (previously it was just the vertical sum). 