### PR TITLE
Fix tiles to llc bug

### DIFF
--- a/ecco_v4_py/llc_array_conversion.py
+++ b/ecco_v4_py/llc_array_conversion.py
@@ -777,49 +777,15 @@ def llc_tiles_to_xda(data_tiles, var_type=None, grid_da=None, less_output=False,
     if var_type is None and grid_da is None:
         raise TypeError('Must specify var_type="c","w","s", or "z" if grid_da is not provided')
 
-    # Reshape data to match xmitgcm dimension order
-    # Want it in [N_recs, N_z, N_tiles, N_j, N_i]
-    if len(data_tiles.shape)==5:
-        if not less_output:
-            print('Found 5D array, assuming [N_tiles, N_recs, N_z, N_y, N_x]')
-            print('Swapping dims 0 <-> 1')
-
-        data_tiles = data_tiles.swapaxes(0,1)
-
-        if not less_output:
-            print('Array shape is now:')
-            print(data_tiles.shape)
-            print('Swapping dims 1 <-> 2')
-
-        data_tiles = data_tiles.swapaxes(1,2)
-        if not less_output:
-            print('Array shape is now:')
-            print(data_tiles.shape)
-
-    elif len(data_tiles.shape)==4:
-        if not less_output:
-            print('Found 4D array, assuming [N_tiles, N_?, N_y, N_x]')
-            print('Swapping dims 0 <-> 1')
-
-        data_tiles = data_tiles.swapaxes(0,1)
-
-        if not less_output:
-            print('Array shape is now:')
-            print(data_tiles.shape)
-
-    elif len(data_tiles.shape)==3:
-        if not less_output:
-            print('Found 3D array, assuming [N_tiles, N_y, N_x]')
-            print('No swapping necessary')
-    elif len(data_tiles.shape)==1:
+    # Test for special case: 1D data
+    if len(data_tiles.shape)==1:
         if grid_da is None:
             raise TypeError('If converting 1D array, must specify grid_da as template')
 
         if not less_output:
             print('Found 1D array, will use grid_da input to shape it')
-
-    else:
-        raise TypeError('Found unfamiliar array shape: %d' % data_tiles.shape)
+    elif len(data_tiles.shape)>5:
+        raise TypeError('Found unfamiliar array shape: ', data_tiles.shape)
 
     # If a DataArray or Dataset is given to model after, use this first!
     if grid_da is not None:

--- a/ecco_v4_py/read_bin_llc.py
+++ b/ecco_v4_py/read_bin_llc.py
@@ -397,7 +397,7 @@ def read_llc_to_tiles_xmitgcm(fdir, fname, llc=90, skip=0, nk=1, nl=1,
     full_filename = '%s/%s' % (fdir,fname)
 
     if not less_output:
-        print (full_filename)
+        print('full_filename: ',full_filename)
     
     # Handle "skipped" records by reading up until that record, and
     # dropping preceding records afterward
@@ -413,25 +413,17 @@ def read_llc_to_tiles_xmitgcm(fdir, fname, llc=90, skip=0, nk=1, nl=1,
     data_tiles = xmitgcm.utils.read_3d_llc_data(full_filename, nx=llc, nz=nk,
                                                 nrecs=nrecs, dtype=filetype)
 
-    print (data_tiles.shape)
-    
     # Handle cases of single or multiple records, and skip>0
-    # Also, swap so that Ntiles dim is ALWAYS first 
-    # for ecco_v4_py convention
     if nl==1:
         # Only want 1 record
         data_tiles = data_tiles[skip_3d,...]
-    #    if nk>1:
-    #        data_tiles = data_tiles.swapaxes(0,1)
 
     else:
         # Want more than one record
         data_tiles = data_tiles[skip_3d:skip_3d+nl,...]
 
-    #     if nk>1:
-    #         data_tiles = data_tiles.swapaxes(1,2)
-
-    #    data_tiles = data_tiles.swapaxes(0,1)
+    if not less_output:
+        print('data_tiles shape = ',data_tiles.shape)
 
     # return the array
     return data_tiles


### PR DESCRIPTION
What I want some feedback on: I found `llc_array_conversion.llc_tiles_to_xda` confusing even though I wrote the damn thing. Specifically, the function required the user to specify dim3 and potentially dim4 as the third and fourth dimensions to a field, being depth or time. This is confusing because this routine works specifically on tiled data, so on a tiled array these would be actually dim4 and dim5 (and this is how the function refers to these dimensions). I went with the latter definition, asking for dim4/5 rather than dim3/4. Let me know if you do/don't agree. 

This also deletes the now commented code of swapping axes in `read_bin_llc.read_llc_to_tiles_xmitgcm`, and removed all the corresponding axis swapping in `llc_array_conversion.llc_tiles_to_xda`. 

More mundane: this fixes two bugs in `llc_array_conversion._make_data_array`
1. There was an old "assumption" statement on the extra dimensions being depth or time, this was causing an error and is removed in preference of making the user specify 4th and/or 5th dimensions being time/depth
2. The 5th dimension was being added on incorrectly, calling the data associated with dim 4 ... 