### PR TITLE
Fix read_llc_to_tiles dimension order

### DIFF
--- a/ecco_v4_py/llc_array_conversion.py
+++ b/ecco_v4_py/llc_array_conversion.py
@@ -55,6 +55,9 @@ def llc_compact_to_tiles(data_compact, less_output = False):
                     llc_compact_to_faces(data_compact,
                                          less_output=less_output), 
                     less_output=less_output)
+
+    # Squeeze out singleton dimension
+    data_tiles = np.squeeze(data_tiles)
         
     return data_tiles
 
@@ -421,7 +424,7 @@ def llc_faces_to_tiles(F, less_output=False):
                 data_tiles[l,k,11,:] = f5[l,k,:,llc*1:llc*2]
                 data_tiles[l,k,12,:] = f5[l,k,:,llc*2:]
 
-    data_tiles = np.squeeze(data_tiles)
+
 
 
     return data_tiles

--- a/ecco_v4_py/llc_array_conversion.py
+++ b/ecco_v4_py/llc_array_conversion.py
@@ -56,9 +56,6 @@ def llc_compact_to_tiles(data_compact, less_output = False):
                                          less_output=less_output), 
                     less_output=less_output)
 
-    # Squeeze out singleton dimension
-    data_tiles = np.squeeze(data_tiles)
-        
     return data_tiles
 
 # %%

--- a/ecco_v4_py/llc_array_conversion.py
+++ b/ecco_v4_py/llc_array_conversion.py
@@ -348,14 +348,14 @@ def llc_faces_to_tiles(F, less_output=False):
 
     elif num_dims == 3: # we have 3D slices (time or depth, y, x)
         nk = dims[0]
-        data_tiles = np.zeros((13, nk, llc, llc))
+        data_tiles = np.zeros((nk, 13, llc, llc))
 
 
     elif num_dims == 4: # we have a 4D slice (time or depth, time or depth, y, x)
         nl = dims[0]
         nk = dims[1]
 
-        data_tiles = np.zeros((13, nl, nk, llc, llc))
+        data_tiles = np.zeros((nl, nk, 13, llc, llc))
     
     else:
         print ('can only handle face arrays that have 2, 3, or 4 dimensions!')
@@ -388,38 +388,40 @@ def llc_faces_to_tiles(F, less_output=False):
     if num_dims == 3:
         # loop over k
         for k in range(nk):
-            data_tiles[0,k,:]  = f1[k,llc*0:llc*1,:]
-            data_tiles[1,k,:]  = f1[k,llc*1:llc*2,:]
-            data_tiles[2,k,:]  = f1[k,llc*2:,:]
-            data_tiles[3,k,:]  = f2[k,llc*0:llc*1,:]
-            data_tiles[4,k,:]  = f2[k,llc*1:llc*2,:]
-            data_tiles[5,k,:]  = f2[k,llc*2:,:]
-            data_tiles[6,k,:]  = f3[k,:]
-            data_tiles[7,k,:]  = f4[k,:,llc*0:llc*1]
-            data_tiles[8,k,:]  = f4[k,:,llc*1:llc*2]
-            data_tiles[9,k,:]  = f4[k,:,llc*2:]
-            data_tiles[10,k,:] = f5[k,:,llc*0:llc*1]
-            data_tiles[11,k,:] = f5[k,:,llc*1:llc*2]
-            data_tiles[12,k,:] = f5[k,:,llc*2:]
+            data_tiles[k,0,:]  = f1[k,llc*0:llc*1,:]
+            data_tiles[k,1,:]  = f1[k,llc*1:llc*2,:]
+            data_tiles[k,2,:]  = f1[k,llc*2:,:]
+            data_tiles[k,3,:]  = f2[k,llc*0:llc*1,:]
+            data_tiles[k,4,:]  = f2[k,llc*1:llc*2,:]
+            data_tiles[k,5,:]  = f2[k,llc*2:,:]
+            data_tiles[k,6,:]  = f3[k,:]
+            data_tiles[k,7,:]  = f4[k,:,llc*0:llc*1]
+            data_tiles[k,8,:]  = f4[k,:,llc*1:llc*2]
+            data_tiles[k,9,:]  = f4[k,:,llc*2:]
+            data_tiles[k,10,:] = f5[k,:,llc*0:llc*1]
+            data_tiles[k,11,:] = f5[k,:,llc*1:llc*2]
+            data_tiles[k,12,:] = f5[k,:,llc*2:]
 
     # -- 4D case
     if num_dims == 4:
         #loop over l and k
         for l in range(nl):
             for k in range(nk):
-                data_tiles[0,l,k,:]  = f1[l,k,llc*0:llc*1,:]
-                data_tiles[1,l,k,:]  = f1[l,k,llc*1:llc*2,:]
-                data_tiles[2,l,k,:]  = f1[l,k,llc*2:,:]
-                data_tiles[3,l,k,:]  = f2[l,k,llc*0:llc*1,:]
-                data_tiles[4,l,k,:]  = f2[l,k,llc*1:llc*2,:]
-                data_tiles[5,l,k,:]  = f2[l,k,llc*2:,:]
-                data_tiles[6,l,k,:]  = f3[l,k,:]
-                data_tiles[7,l,k,:]  = f4[l,k,:,llc*0:llc*1]
-                data_tiles[8,l,k,:]  = f4[l,k,:,llc*1:llc*2]
-                data_tiles[9,l,k,:]  = f4[l,k,:,llc*2:]
-                data_tiles[10,l,k,:] = f5[l,k,:,llc*0:llc*1]
-                data_tiles[11,l,k,:] = f5[l,k,:,llc*1:llc*2]
-                data_tiles[12,l,k,:] = f5[l,k,:,llc*2:]
+                data_tiles[l,k,0,:]  = f1[l,k,llc*0:llc*1,:]
+                data_tiles[l,k,1,:]  = f1[l,k,llc*1:llc*2,:]
+                data_tiles[l,k,2,:]  = f1[l,k,llc*2:,:]
+                data_tiles[l,k,3,:]  = f2[l,k,llc*0:llc*1,:]
+                data_tiles[l,k,4,:]  = f2[l,k,llc*1:llc*2,:]
+                data_tiles[l,k,5,:]  = f2[l,k,llc*2:,:]
+                data_tiles[l,k,6,:]  = f3[l,k,:]
+                data_tiles[l,k,7,:]  = f4[l,k,:,llc*0:llc*1]
+                data_tiles[l,k,8,:]  = f4[l,k,:,llc*1:llc*2]
+                data_tiles[l,k,9,:]  = f4[l,k,:,llc*2:]
+                data_tiles[l,k,10,:] = f5[l,k,:,llc*0:llc*1]
+                data_tiles[l,k,11,:] = f5[l,k,:,llc*1:llc*2]
+                data_tiles[l,k,12,:] = f5[l,k,:,llc*2:]
+
+    data_tiles = np.squeeze(data_tiles)
 
 
     return data_tiles


### PR DESCRIPTION
Currently the dimension order of a given data set is not consistent across functions. With #42, `read_llc_to_tiles` reads in data and puts the tile dimension FIRST no matter what. That means 3D spatial data have dimensions [N_tiles, N_vertical, N_llc, N_llc], time varying 2D spatial data have dimensions [N_tiles, N_time, N_llc, N_llc], and time varying 3D spatial data have dimensions [N_tiles, N_time, N_vertical, N_llc, N_llc]. This is contradictory to `read_llc_to_tiles_xmitgcm`, which has the dimension order [N_time, N_vertical, N_tiles, N_llc, N_llc], and any singleton dimensions are dropped. I'll mention that this is why I previously had all of the swapaxes calls in this function - in order to be consistent with previous functionality and to be consistent with `llc_array_conversion` routines.

I would argue that the latter dimension order should be followed because (1) it seems more intuitive to me, (2) it follows the xmitgcm convention, which would be nice to agree so that a dataset read in through xmitgcm has the same underlying dimension order with what is read in with this routine, (3) less has to be changed with the current implementation of `llc_tiles_to_xda`.

This implements that change, and makes sure that singleton dimensions are squeezed out.