### PR TITLE
code improvements for generating netcdf files

### DIFF
--- a/ecco_v4_py/ecco_utils.py
+++ b/ecco_v4_py/ecco_utils.py
@@ -69,7 +69,7 @@ def make_time_bounds_and_center_times_from_ecco_dataset(ecco_dataset, \
         time_start = []
         time_end  = []
         center_time = []
-        for time_i in range(len(ecco_dataset.iter)):
+        for time_i in range(len(ecco_dataset.timestep)):
              tb, ct = \
                  make_time_bounds_from_ds64(ecco_dataset.time.values[time_i], 
                                   output_freq_code)

--- a/ecco_v4_py/read_bin_llc.py
+++ b/ecco_v4_py/read_bin_llc.py
@@ -193,8 +193,11 @@ def load_ecco_vars_from_mds(mds_var_dir,
     # replace the xmitgcm coordinate name of 'FACE' with 'TILE'
     if 'face' in ecco_dataset.coords.keys():
         ecco_dataset = ecco_dataset.rename({'face': 'tile'})
-        ecco_dataset.tile.attrs['standard_name'] = 'tile_index'
+        ecco_dataset.tile.attrs['long_name'] = 'index of llc grid tile'
        
+    if 'iter' in ecco_dataset.coords.keys():
+        ecco_dataset = ecco_dataset.rename({'iter': 'timestep'})
+        ecco_dataset.tile.attrs['long_name'] = 'model time step'
     # if vars_to_load is an empty list, keep all variables.  otherwise,
     # only keep those variables in the vars_to_load list.
     
@@ -287,9 +290,6 @@ def load_ecco_vars_from_mds(mds_var_dir,
         if 'ecco-v4-time-average-center-no-units' in meta_common:
             ecco_dataset.time.attrs = \
                 meta_common['ecco-v4-time-average-center-no-units']
-          
-        
-      
 
         if not less_output:
             print ('dataset times : ', ecco_dataset.time.values)
@@ -309,8 +309,18 @@ def load_ecco_vars_from_mds(mds_var_dir,
         ecco_dataset=ecco_dataset.drop('maskCtrlC')
         
     # UPDATE THE VARIABLE SPECIFIC METADATA USING THE 'META_VARSPECIFIC' DICT.
-    # if it exists
+    # if it exists...
     for ecco_var in ecco_dataset.variables.keys():
+
+        # always drop whatever is in the standard name field
+        if 'standard_name' in ecco_dataset[ecco_var].attrs.keys():
+            ecco_dataset[ecco_var].attrs.pop('standard_name')
+    
+        ecco_dataset[ecco_var].encoding['_FillValue'] = False
+
+
+        # use the variable specific keys from the meta_variable_specific
+        # dictionary
         if ecco_var in meta_variable_specific.keys():
             ecco_dataset[ecco_var].attrs = meta_variable_specific[ecco_var]
 
@@ -328,7 +338,7 @@ def load_ecco_vars_from_mds(mds_var_dir,
     ecco_dataset.attrs['date_created'] = time.ctime()
     
     # give it a hug?
-    ecco_dataset = ecco_dataset.squeeze()
+    # ecco_dataset = ecco_dataset.squeeze()
 
     return ecco_dataset
 

--- a/meta_json/ecco_meta_common.json
+++ b/meta_json/ecco_meta_common.json
@@ -41,10 +41,10 @@
   }, 
   "ecco-v4-time_bnds": {
     "units": "days since 1992-01-01 00:00:00", 
-    "long_name": "time bounds of averaging period", 
+    "long_name": "time bounds of averaging period"
   }, 
   "time_bnds-no-units": {
-    "long_name": "time bounds of averaging period", 
+    "long_name": "time bounds of averaging period" 
   }, 
 
   "ecco-v4-native-grid": {
@@ -145,11 +145,11 @@
   }, 
   "latitude_bnds": {
     "units": "degrees_north", 
-    "long_name": "latitude bounds", 
+    "long_name": "latitude bounds"
   }, 
   "longitude_bnds": {
     "units": "degrees_east", 
-    "long_name": "longitude bounds", 
+    "long_name": "longitude bounds"
   }, 
   "3d": {
     "depth": {


### PR DESCRIPTION
1. changed 'iter' to 'timestep' everywhere
2. two choices now for generating netcdf files 
   *time_interval_and_combined_tiles* : one file per time interval, no split on tiles
   *time_interval_and_separate_tiles* : one file per time interval and tile
3. better dropping of grid coordinates
4. better handling of geospatial coords (especially vertical)
5. removed default 'standard names' that appear with xmitgcm
6. removed default '_FillValue' that xarray uses
7. specified netcdf4 as netcdf engine when writing netcdfs
8. fixed several trailing commas in the meta_common file which was causing errors
9. improved reading of *data/*meta files.  used to read one file at a time which forced reloading of the grid fields.  now all timesteps are 'loaded' first (using dask) which only causes the grid to be read one time
