### PR TITLE
Fix incorrect long_time for tile attribute

### DIFF
--- a/ecco_v4_py/read_bin_llc.py
+++ b/ecco_v4_py/read_bin_llc.py
@@ -197,7 +197,8 @@ def load_ecco_vars_from_mds(mds_var_dir,
        
     if 'iter' in ecco_dataset.coords.keys():
         ecco_dataset = ecco_dataset.rename({'iter': 'timestep'})
-        ecco_dataset.tile.attrs['long_name'] = 'model time step'
+        #xgcm aleardy has set the long_name for timestep.
+        #ecco_dataset.timestep.attrs['long_name'] = 'model time step'
     # if vars_to_load is an empty list, keep all variables.  otherwise,
     # only keep those variables in the vars_to_load list.
     

--- a/ecco_v4_py/read_bin_llc.py
+++ b/ecco_v4_py/read_bin_llc.py
@@ -197,7 +197,7 @@ def load_ecco_vars_from_mds(mds_var_dir,
        
     if 'iter' in ecco_dataset.coords.keys():
         ecco_dataset = ecco_dataset.rename({'iter': 'timestep'})
-        #xgcm aleardy has set the long_name for timestep.
+        #xmitgcm aleardy has set the long_name for timestep.
         #ecco_dataset.timestep.attrs['long_name'] = 'model time step'
     # if vars_to_load is an empty list, keep all variables.  otherwise,
     # only keep those variables in the vars_to_load list.


### PR DESCRIPTION
Fix the incorrect long_time for the tile attribute. Was set to "model time step". 

Also, comment out the following line in read_bin_llc.py
ecco_dataset.timestep.attrs['long_name'] = 'model time step'
since it has been set in xmitgcm.