### PR TITLE
look for files, otherwise skip test

### DIFF
--- a/ecco_v4_py/test/test_llc_array_conversion.py
+++ b/ecco_v4_py/test/test_llc_array_conversion.py
@@ -1,14 +1,14 @@
 
 from __future__ import division, print_function
 import warnings
-import os
+from pathlib import Path
 import numpy as np
 import pytest
 import ecco_v4_py as ecco
 
 # Define bin directory for test reading
-_PKG_DIR = os.path.dirname(os.path.abspath(__file__))
-_DATA_DIR = os.path.join(_PKG_DIR,'../../binary_data')
+_PKG_DIR = Path.cwd().resolve().parent.parent
+_DATA_DIR = _PKG_DIR.joinpath('binary_data')
 
 _TEST_FILES = ['basins.data', 'hFacC.data', 'state_3d_set1.0000000732.data']
 _TEST_NK = [1, 50, 50]
@@ -17,9 +17,9 @@ _TEST_RECS = [1, 1, 3]
 
 # Look for files #
 ##################
-if not os.path.isfile(os.path.join(_DATA_DIR,_TEST_FILES[0])):
+if not _DATA_DIR.joinpath(_TEST_FILES[0]).is_file():
 
-    warnings.warn('\n\nCannot find necessary binaries in ' + _DATA_DIR + '\n' +\
+    warnings.warn('\n\nCannot find necessary binaries in ' + str(_DATA_DIR) + '\n' +\
     'You can download all *.meta/data files needed for testing here:\n' +\
     '   https://github.com/ECCO-GROUP/ECCOv4-py/tree/master/binary_data \n' +\
     ' or \n' +\

--- a/ecco_v4_py/test/test_llc_array_conversion.py
+++ b/ecco_v4_py/test/test_llc_array_conversion.py
@@ -1,7 +1,9 @@
 
 from __future__ import division, print_function
+import warnings
 import os
 import numpy as np
+import pytest
 import ecco_v4_py as ecco
 
 # Define bin directory for test reading
@@ -12,6 +14,18 @@ _TEST_FILES = ['basins.data', 'hFacC.data', 'state_3d_set1.0000000732.data']
 _TEST_NK = [1, 50, 50]
 _TEST_RECS = [1, 1, 3]
 
+
+# Look for files #
+##################
+if not os.path.isfile(os.path.join(_DATA_DIR,_TEST_FILES[0])):
+
+    warnings.warn('\n\nCannot find necessary binaries in ' + _DATA_DIR + '\n' +\
+    'You can download all *.meta/data files needed for testing here:\n' +\
+    '   https://github.com/ECCO-GROUP/ECCOv4-py/tree/master/binary_data \n' +\
+    ' or \n' +\
+    '   https://figshare.com/articles/Binary_files_for_the_ecco-v4-py_Python_package_/9932162 \n' +\
+    'Download these files to ecco_v4_py/../binary_data/')
+    pytest.skip("Test files not available.",allow_module_level=True)
 
 # Test convert from tiles #
 ###########################


### PR DESCRIPTION
Hey @ifenty, this test module `ecco_v4_py/test/test_llc_array_conversion.py` is what I mentioned in #72. 

This PR adds the functionality to look for the necessary test files, otherwise skip the tests and print out a message telling the user where to find the files. I couldn't find a good way to find out what the user's username is to additionally search in `/home/username/bin`, other than [this stack exchange answer](https://stackoverflow.com/questions/842059/is-there-a-portable-way-to-get-the-current-username-in-python). However, this relies on the `getpass` package which I doubt anyone would have anyway (it doesn't come with anaconda for example).

I'm asking you to review this because this test module is somewhat a duplicate of `ecco_v4_py/test_llc_array_loading_and_conversion.py`, and I'm wondering if you would be ok with removing that one, otherwise we can move it to the `test/` dir. The differences are that this module doesn't make plots and I think it's a bit more compact. Also, the module is designed to work with [pytest](https://docs.pytest.org/en/latest/) as:

```
pytest test_llc_array_conversion.py
```

I did this in #54 so that *eventually* if we get something like [travis-ci](https://travis-ci.org/) to do automated testing, which I think we should do this whenever we have time (heh), this would be ready to roll. Also it hides the tests in a `test/` dir, separate from the rest of the modules.