### PR TITLE
More pathlib, plotting gridlines, and netcdf reading

### DIFF
--- a/ecco_v4_py/netcdf_product_generation.py
+++ b/ecco_v4_py/netcdf_product_generation.py
@@ -21,6 +21,7 @@ import os
 import sys
 import pyresample as pr
 import json
+import pathlib
 
 from .read_bin_llc import load_ecco_vars_from_mds
 from .ecco_utils import extract_yyyy_mm_dd_hh_mm_ss_from_datetime64
@@ -28,12 +29,12 @@ from .resample_to_latlon import resample_to_latlon
 
 #%%    
 def create_nc_grid_files_on_native_grid_from_mds(grid_input_dir, 
-                                                grid_output_dir, 
-                                                meta_variable_specific = [],
-                                                meta_common = [], 
-                                                title_basename='ECCOv4r3_grid_tile_',
-                                                title='ECCOv4R3 MITgcm grid information',
-                                                mds_datatype = '>f4'):
+                                                 grid_output_dir, 
+                                                 meta_variable_specific = [],
+                                                 meta_common = [], 
+                                                 title_basename='ECCOv4r3_grid_tile_',
+                                                 title='ECCOv4R3 MITgcm grid information',
+                                                 mds_datatype = '>f4'):
     
     mds_files = ''
 

--- a/ecco_v4_py/tile_plot_proj.py
+++ b/ecco_v4_py/tile_plot_proj.py
@@ -31,8 +31,8 @@ def plot_proj_to_latlon_grid(lons, lats, data,
                              show_colorbar = False, 
                              show_grid_lines = True,
                              show_grid_labels = True,
-		 	                 grid_linewidth = 1, 
-	   	 	                 grid_linestyle = '--', 
+		 	                         grid_linewidth = 1, 
+     	   	 	                 grid_linestyle = '--', 
                              subplot_grid=None,
                              less_output=True,
                              custom_background = False,
@@ -187,7 +187,7 @@ def plot_proj_to_latlon_grid(lons, lats, data,
                              show_colorbar=False, 
                              circle_boundary=True,
                              cmap=cmap, 
-                             show_grid_lines=False,
+                             show_grid_lines=show_grid_labels,
                              custom_background = custom_background,
                              background_name = background_name,
                              background_resolution = background_resolution,
@@ -203,24 +203,24 @@ def plot_proj_to_latlon_grid(lons, lats, data,
                             plot_type = plot_type,                                       
                             show_colorbar = False,
                             cmap=cmap, 
-			                show_grid_lines = False,
+         			                show_grid_lines = False,
                             custom_background = custom_background,
                             background_name = background_name,
                             background_resolution = background_resolution,
-                            show_grid_labels = False)
+                            show_grid_labels = show_grid_labels)
 			    
                     
         if show_grid_lines :
             ax.gridlines(crs=ccrs.PlateCarree(), 
                                   linewidth=grid_linewidth,
-				  color='black', 	
+                            				  color='black', 	
                                   alpha=0.5, 
-				  linestyle=grid_linestyle, 
-                                  draw_labels = show_grid_labels)
+                            				  linestyle=grid_linestyle, 
+                                  draw_labels = show_grid_labels,zorder=102)
         
-         #%%
-        # ax.add_feature(cfeature.LAND)
-        #ax.add_feature(cfeature.COASTLINE,linewidth=0.5)
+       
+        ax.add_feature(cfeature.LAND, zorder=100)
+        ax.add_feature(cfeature.COASTLINE,linewidth=0.5,zorder=101)
 
     ax= plt.gca()
 
@@ -280,7 +280,7 @@ def plot_pstereo(xx,yy, data,
     if show_grid_lines :
         gl = ax.gridlines(crs=ccrs.PlateCarree(), 
                           linewidth=grid_linewidth, color='black', 
-                          alpha=0.5, linestyle=grid_linestyle)
+                          alpha=0.5, linestyle=grid_linestyle, zorder=102)
     else:
         gl = []
 
@@ -306,8 +306,9 @@ def plot_pstereo(xx,yy, data,
         raise ValueError('plot_type  must be either "pcolormesh" or "contourf"')
 
     if not custom_background:     
-        ax.add_feature(cfeature.LAND)
-    ax.coastlines('110m', linewidth=0.8)
+        ax.add_feature(cfeature.LAND, zorder=100)
+
+    ax.coastlines('110m', linewidth=0.8, zorder=101)
 
     cbar = []
     if show_colorbar:
@@ -327,7 +328,7 @@ def plot_global(xx,yy, data,
                 cmap='jet', 
                 show_grid_lines = True,
                 show_grid_labels = True,
-		        grid_linewidth = 1, 
+      		        grid_linewidth = 1, 
                 custom_background = False,
                 background_name = [],
                 background_resolution = [],
@@ -337,7 +338,7 @@ def plot_global(xx,yy, data,
         gl = ax.gridlines(crs=ccrs.PlateCarree(), 
                           linewidth=1, color='black', 
                           draw_labels = show_grid_labels,
-                          alpha=0.5, linestyle='--')
+                          alpha=0.5, linestyle='--', zorder=102)
     else:
         gl = []
         

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from distutils.core import setup
 setup(
   name = 'ecco_v4_py',
   packages = ['ecco_v4_py'], # this must be the same as the name above
-  version = '1.1.4',
+  version = '1.1.5',
   description = 'Estimating the Circulation and Climate of the Ocean (ECCO) Version 4 Python Package',
   author = 'Ian Fenty',
   author_email = 'ian.fenty@jpl.nasa.gov',


### PR DESCRIPTION
1. pathlib
    a. fixed use of pathlib in reading ecco grid files

2. plotting
    a. added the ability of the user to specify whether they want grid lines on plots.  
    b. used zorder so that land, coastlines, and gridlines are plotted on TOP of the fields to be plotted in (land below coastlines below gridlines)

3. i/o
   a. made it easier to find the year in netcdf filenames (when you find a number surrounded by  '_' in the name, try to turn it into a number and see if is larger than 1900.  If so, assume it's the filename and assume everything before that is the variable name.  This was needed because variable names like ADVx_TH have an extra '_' in them which makes it harder to just split by '_'.

All of the tutorials were also updated to work with this code as well. 
