### PR TITLE
only look for section name if not None

### DIFF
--- a/ecco_v4_py/calc_section_trsp.py
+++ b/ecco_v4_py/calc_section_trsp.py
@@ -308,8 +308,9 @@ def _parse_section_trsp_inputs(ds,pt1,pt2,maskW,maskS,section_name):
     use_masks = False
 
     # Test if section name is in available basins
-    if get_section_endpoints(section_name) is not None:
-        use_predefined_section = True
+    if section_name is not None:
+        if get_section_endpoints(section_name) is not None:
+            use_predefined_section = True
 
     # Test if endpoints provided
     if (pt1 is not None and pt2 is not None):


### PR DESCRIPTION
Just a quick bug fix: if a user computes a section transport without providing a name, e.g. by providing lat/lon pairs or by providing masks, the helper function `get_section_endpoints` errors out because it gets passed None but reasonably expects a string. 

I just modified `_parse_section_trsp_inputs` to only call `get_section_endpoints` (i.e. look for a predefined section) if section_name is not None. 