### PR TITLE
Fix tile plot

### DIFF
--- a/ecco_v4_py/plot_utils.py
+++ b/ecco_v4_py/plot_utils.py
@@ -1,0 +1,51 @@
+"""
+Some helper functions for plotting
+"""
+
+import numpy as np
+import xarray as xr
+import dask
+
+def assign_colormap(fld,user_cmap):
+    """assign a default colormap based on input field
+    following xarray defaults
+
+    Sequential fld: viridis
+    Divergent fld : RdBu_r
+    
+
+    Parameters
+    ----------
+    fld : xarray.DataArray or numpy.ndarray
+        must be in tiled format
+
+    user_cmap : str or None
+        if user_cmap is specified, use this
+        will be None if not specified, and default used
+
+    Returns
+    -------
+    cmap : str
+        assigned colormap depending on diverging or sequential
+        data in field
+
+    (cmin,cmax) : tuple of floats
+        minimum and maximum values for colormap
+    """
+
+    #%%    
+    # If fld span positive/negative, default to normalize about 0
+    # otherwise, regular (sequential). Assign cmap accordingly.
+    cmin = np.nanmin(fld)
+    cmax = np.nanmax(fld)
+    if cmin*cmax<0:
+        cmax=np.nanmax(np.abs(fld))
+        cmin=-cmax
+        cmap = 'RdBu_r'
+    else:
+        cmap = 'viridis'
+
+    # override if user_cmap is not None
+    cmap = cmap if user_cmap is None else user_cmap
+
+    return cmap, (cmin,cmax)

--- a/ecco_v4_py/test/test_plot_utils.py
+++ b/ecco_v4_py/test/test_plot_utils.py
@@ -1,0 +1,60 @@
+"""
+Test routines for the tile plotting
+"""
+from __future__ import division, print_function
+import warnings
+from pathlib import Path
+import numpy as np
+import pytest
+import ecco_v4_py as ecco
+
+from ecco_v4_py.plot_utils import assign_colormap
+
+# Define bin directory for test reading
+_PKG_DIR = Path.cwd().resolve().parent.parent
+_DATA_DIR = _PKG_DIR.joinpath('binary_data')
+
+_TEST_FILES = ['basins.data', 'hFacC.data', 'state_3d_set1.0000000732.data']
+_TEST_NK = [1, 50, 50]
+_TEST_RECS = [1, 1, 3]
+
+def get_test_array(is_xda=False):
+    """define a numpy and xarray DataArray for testing"""
+
+    # read in as numpy array
+    test_arr = ecco.read_llc_to_tiles(fdir=_DATA_DIR,
+                                      fname=_TEST_FILES[0],
+                                      less_output=True)
+
+    if is_xda:
+        test_arr = ecco.llc_tiles_to_xda(test_arr,var_type='c',less_output=True)
+
+    return test_arr
+
+# ----------------------------------------------------------------
+# tests
+# ----------------------------------------------------------------
+@pytest.mark.parametrize("arr",[
+        get_test_array(is_xda=False),
+        get_test_array(is_xda=True)
+    ])
+def test_cmap_override(arr):
+    """make sure if user provides cmap, it overrides default"""
+
+    # run plotting routine
+    cmap_expected = 'inferno'
+
+    cmap_test, _ = assign_colormap(arr,user_cmap=cmap_expected)
+    assert cmap_test == cmap_expected
+
+@pytest.mark.parametrize("arr",[
+        get_test_array(is_xda=False),
+        get_test_array(is_xda=True)
+    ])
+def test_cminmax_dtype(arr):
+    """make cmin/cmax are floats"""
+
+    _, (cmin,cmax) = assign_colormap(arr,user_cmap=None)
+        
+    assert isinstance(cmin,float)
+    assert isinstance(cmax,float)

--- a/ecco_v4_py/test/test_tile_plot.py
+++ b/ecco_v4_py/test/test_tile_plot.py
@@ -8,6 +8,8 @@ import numpy as np
 import pytest
 import ecco_v4_py as ecco
 
+from .test_plot_utils import get_test_array
+
 # Define bin directory for test reading
 _PKG_DIR = Path.cwd().resolve().parent.parent
 _DATA_DIR = _PKG_DIR.joinpath('binary_data')
@@ -16,31 +18,58 @@ _TEST_FILES = ['basins.data', 'hFacC.data', 'state_3d_set1.0000000732.data']
 _TEST_NK = [1, 50, 50]
 _TEST_RECS = [1, 1, 3]
 
-def get_default_plot_tiles_input():
-    """make a dict with default inputs"""
-    return {'cmap':None,
-            'layout':'llc',
-            'rotate_to_latlon':False,
-            'show_colorbar':False,
-            'show_cbar_label':False,
-            'show_tile_labels':True,
-            'fig_size':9,
-            'less_output':True}
-
-@pytest.mark.parametrize("fname,vdict",[
-        (_TEST_FILES[0],{}), # test defaults
-        (_TEST_FILES[0],{'layout':'latlon', 
-                         'rotate_to_latlon':False),
-        (_TEST_FILES[0],{'layout':'latlon',
-                         'rotate_to_latlon':False,
-                         'Arctic_cap_tile_location':5}),
+@pytest.mark.parametrize("vdict",[
+        {}, #defaults
+        {'cmap':'plasma'},
+        {'layout':'latlon', 
+          'rotate_to_latlon':False},
+        {'layout':'latlon',
+         'rotate_to_latlon':False,
+         'Arctic_cap_tile_location':5},
+        {'layout':'latlon',
+         'rotate_to_latlon':False,
+         'Arctic_cap_tile_location':7},
+        {'layout':'latlon',
+         'rotate_to_latlon':False,
+         'Arctic_cap_tile_location':10},
+        {'show_colorbar':True},
+        {'show_colorbar':True,
+         'show_cbar_label':True,
+         'cbar_label':'something good'},
+        {'show_tile_labels':False},
+        {'fig_size':20},
+        {'less_output':False}
     ])
-def test_plot_tiles(fname,vdict):
+def test_plot_tiles(vdict):
     """Run through various options and make sure nothing is broken"""
 
-    #get defaults
-    inputs=get_default_plot_tiles_input()
-    for key, val in vdict.items():
-        inputs[key] = val
+    # read in array
+    nparr = get_test_array(is_xda=False)
+    xda = get_test_array(is_xda=True)
 
-    # 
+    # run plotting routine
+    for arr in [nparr,xda]:
+        ecco.plot_tiles(arr, **vdict)
+
+@pytest.mark.parametrize("vdict",[
+        {}, #defaults
+        {'cmap':'plasma'},
+        {'show_colorbar':True},
+        {'show_colorbar':True,
+         'show_cbar_label':True,
+         'cbar_label':'something good'},
+        {'show_tile_labels':False},
+        {'less_output':False}
+    ])
+def test_plot_single_tile(vdict):
+    """plot a single tile"""
+
+    # read in array
+    nparr = get_test_array(is_xda=False)
+    xda = get_test_array(is_xda=True)
+
+    # run plotting routine on each tile
+    for t in xda.tile.values:
+
+        ecco.plot_tile(nparr[t,...], **vdict)
+        ecco.plot_tile(xda.sel(tile=t), **vdict)

--- a/ecco_v4_py/test/test_tile_plot.py
+++ b/ecco_v4_py/test/test_tile_plot.py
@@ -1,0 +1,46 @@
+"""
+Test routines for the tile plotting
+"""
+from __future__ import division, print_function
+import warnings
+from pathlib import Path
+import numpy as np
+import pytest
+import ecco_v4_py as ecco
+
+# Define bin directory for test reading
+_PKG_DIR = Path.cwd().resolve().parent.parent
+_DATA_DIR = _PKG_DIR.joinpath('binary_data')
+
+_TEST_FILES = ['basins.data', 'hFacC.data', 'state_3d_set1.0000000732.data']
+_TEST_NK = [1, 50, 50]
+_TEST_RECS = [1, 1, 3]
+
+def get_default_plot_tiles_input():
+    """make a dict with default inputs"""
+    return {'cmap':None,
+            'layout':'llc',
+            'rotate_to_latlon':False,
+            'show_colorbar':False,
+            'show_cbar_label':False,
+            'show_tile_labels':True,
+            'fig_size':9,
+            'less_output':True}
+
+@pytest.mark.parametrize("fname,vdict",[
+        (_TEST_FILES[0],{}), # test defaults
+        (_TEST_FILES[0],{'layout':'latlon', 
+                         'rotate_to_latlon':False),
+        (_TEST_FILES[0],{'layout':'latlon',
+                         'rotate_to_latlon':False,
+                         'Arctic_cap_tile_location':5}),
+    ])
+def test_plot_tiles(fname,vdict):
+    """Run through various options and make sure nothing is broken"""
+
+    #get defaults
+    inputs=get_default_plot_tiles_input()
+    for key, val in vdict.items():
+        inputs[key] = val
+
+    # 

--- a/ecco_v4_py/test/test_tile_plot.py
+++ b/ecco_v4_py/test/test_tile_plot.py
@@ -73,3 +73,15 @@ def test_plot_single_tile(vdict):
 
         ecco.plot_tile(nparr[t,...], **vdict)
         ecco.plot_tile(xda.sel(tile=t), **vdict)
+
+def test_plot_tiles_array():
+    """a crude test to make sure the array being created
+    matches the original"""
+
+    nparr = get_test_array(is_xda=False)
+    xda = get_test_array(is_xda=True)
+
+    for arr_expected in [nparr,xda]:
+        f,arr_test = ecco.plot_tiles(arr_expected)
+        assert np.nansum(arr_test)==float(np.nansum(arr_expected))
+

--- a/ecco_v4_py/test/test_tile_plot.py
+++ b/ecco_v4_py/test/test_tile_plot.py
@@ -5,6 +5,7 @@ from __future__ import division, print_function
 import warnings
 from pathlib import Path
 import numpy as np
+import matplotlib.pyplot as plt
 import pytest
 import ecco_v4_py as ecco
 
@@ -50,6 +51,7 @@ def test_plot_tiles(vdict):
     # run plotting routine
     for arr in [nparr,xda]:
         ecco.plot_tiles(arr, **vdict)
+        plt.close()
 
 @pytest.mark.parametrize("vdict",[
         {}, #defaults
@@ -72,7 +74,11 @@ def test_plot_single_tile(vdict):
     for t in xda.tile.values:
 
         ecco.plot_tile(nparr[t,...], **vdict)
+        plt.close()
+
         ecco.plot_tile(xda.sel(tile=t), **vdict)
+        plt.close()
+
 
 def test_plot_tiles_array():
     """a crude test to make sure the array being created
@@ -82,6 +88,6 @@ def test_plot_tiles_array():
     xda = get_test_array(is_xda=True)
 
     for arr_expected in [nparr,xda]:
-        f,arr_test = ecco.plot_tiles(arr_expected)
+        _,arr_test = ecco.plot_tiles(arr_expected)
         assert np.nansum(arr_test)==float(np.nansum(arr_expected))
-
+        plt.close()

--- a/ecco_v4_py/tile_plot.py
+++ b/ecco_v4_py/tile_plot.py
@@ -330,8 +330,8 @@ def plot_tiles(tiles, cmap=None,
             if not less_output:
                 print('i=',i,rownum, colnum)
             
-            if rownum*colnum>0 and get_array:
-                cur_arr[colnum*90:colnump1*90, rownum*90:rownump1*90] = cur_tile
+            if cur_tile_num>=0 and get_array:
+                cur_arr[colnum*nx:colnump1*nx, rownum*nx:rownump1*nx] = cur_tile
 
     # show the colorbar
     if show_colorbar:

--- a/ecco_v4_py/tile_plot.py
+++ b/ecco_v4_py/tile_plot.py
@@ -336,7 +336,9 @@ def plot_tiles(tiles, cmap='jet',
             print(type(rownum), type(colnum), type(rownump1))
             #cur_arr[colnum*90:colnump1*90, rownum*90:rownump1*90] = cur_tile
             print('i=',i,rownum, colnum)
-            cur_arr[colnum*90:colnump1*90, rownum*90:rownump1*90] = cur_tile
+            
+            if rownum*colnum>0:
+                cur_arr[colnum*90:colnump1*90, rownum*90:rownump1*90] = cur_tile
             ax.set_aspect('equal')
             ax.axis('on')
             if show_tile_labels:

--- a/ecco_v4_py/tile_plot.py
+++ b/ecco_v4_py/tile_plot.py
@@ -13,6 +13,7 @@ The llc layout is used for ECCO v4.
 
 from __future__ import division, print_function
 import numpy as np
+import warnings
 import matplotlib.pylab as plt
 import xarray as xr
 from distutils.util import strtobool
@@ -20,8 +21,10 @@ import pyresample as pr
 import xmitgcm
 import dask
 
-def plot_tile(tile, cmap='jet', show_colorbar=False,  show_cbar_label=False, 
-              cbar_label = '', **kwargs):
+from .plot_utils import assign_colormap
+
+def plot_tile(tile, cmap=None, show_colorbar=False,  show_cbar_label=False, 
+              cbar_label = '', less_output=True, **kwargs):
     """
 
     Plots a single tile of the lat-lon-cap (LLC) grid
@@ -31,7 +34,8 @@ def plot_tile(tile, cmap='jet', show_colorbar=False,  show_cbar_label=False,
     tile : ndarray
         a single 2D tile of dimension llc x llc 
 
-    cmap : colormap, optional, default jet
+    cmap : colormap, optional
+        see plot_utils.assign_colormap for default
         a colormap for the figure
   
     show_colorbar : boolean, optional, default False
@@ -41,8 +45,8 @@ def plot_tile(tile, cmap='jet', show_colorbar=False,  show_cbar_label=False,
         boolean, show a label on the colorbar
         Default: False
         
-    less_output : boolean, default False
-        A debugging flag.  False = less debugging output
+    less_output : boolean, default True
+        A debugging flag.  True = less debugging output
                 
     cmin/cmax : floats, optional, default calculate using the min/max of the data
         the minimum and maximum values to use for the colormap
@@ -58,9 +62,8 @@ def plot_tile(tile, cmap='jet', show_colorbar=False,  show_cbar_label=False,
 
     """
 
-    # by default take the min and max of the values
-    cmin = np.nanmin(tile)
-    cmax = np.nanmax(tile)
+    # get default cmap and colormap min/max
+    cmap, (cmin,cmax) = assign_colormap(tile,cmap)
     
     fig_num = -1
     #%%
@@ -95,14 +98,16 @@ def plot_tile(tile, cmap='jet', show_colorbar=False,  show_cbar_label=False,
     return f
     
     
-def plot_tiles(tiles, cmap='jet', 
+def plot_tiles(tiles, cmap=None, 
                layout='llc', rotate_to_latlon=False,
                Arctic_cap_tile_location = 2,
                show_colorbar=False,  
                show_cbar_label=False, 
                show_tile_labels= True,
                cbar_label = '', 
-               fig_size = 9,  **kwargs):
+               fig_size = 9,  
+               less_output=True,
+               **kwargs):
     """
 
     Plots the 13 tiles of the lat-lon-cap (LLC) grid
@@ -115,7 +120,8 @@ def plot_tiles(tiles, cmap='jet',
             - If *xarray DataArray* or *dask Array* tiles are accessed via *tiles.sel(tile=n)*
             - If *numpy ndarray* tiles are acceed via [tile,:,:] and thus n must be 13.
 
-    cmap : matplotlib.colors.Colormap, optional, default: jet
+    cmap : matplotlib.colors.Colormap, optional
+        see plot_utils.assign_colormap for default
         a colormap for the figure
 
     layout : string, optional, default 'llc'
@@ -151,8 +157,8 @@ def plot_tiles(tiles, cmap='jet',
     cbar_label : str, optional, default '' (empty string)
         the label to use for the colorbar
       
-    less_output : boolean, optional, default False
-        A debugging flag.  False = less debugging output
+    less_output : boolean, optional, default True
+        A debugging flag.  True = less debugging output
                 
     cmin/cmax : floats, optional, default calculate using the min/max of the data
         the minimum and maximum values to use for the colormap
@@ -165,29 +171,25 @@ def plot_tiles(tiles, cmap='jet',
         
     Returns
     -------
-    f : Figure
-        
+    f : matplotlib figure object
 
+    cur_arr : numpy ndarray
+        numpy array of size:
+            (llc*nrows, llc*ncols)
+        where llc is the size of tile for llc geometry (e.g. 90)
+        nrows, ncols refers to the subplot size
+        For now, only implemented for llc90, otherwise None is returned
     """
 
-    # by default take the min and max of the values
-    
+    # processing for dask array (?)
     if isinstance(tiles, dask.array.core.Array):
         tiles = np.asarray(tiles.squeeze())
-        
-    
-    if type(tiles) == np.ndarray:
-        cmin = np.nanmin(tiles)
-        cmax = np.nanmax(tiles)
-                    
-    elif isinstance(tiles, dask.array.core.Array) or \
-         isinstance(tiles, xr.core.dataarray.DataArray):
-        cmin = np.nanmin(tiles.values)
-        cmax = np.nanmax(tiles.values)
-        
-             
-    fig_num = -1
+
+    # get default colormap
+    cmap, (cmin,cmax) = assign_colormap(tiles,cmap)
+
     #%%
+    fig_num = -1
     for key in kwargs:
         if key == "cmin":
             cmin = kwargs[key]
@@ -198,9 +200,15 @@ def plot_tiles(tiles, cmap='jet',
         else:
             print("unrecognized argument ", key)
 
+    # if llc90, return array otherwise not implemented
+    get_array = True
+    nx = tiles.shape[-1]
+    if nx != 90:
+        get_array = False
+        warnings.warn('Will not return array for non llc90 data')
 
+    # set sizing for subplots
     fac1 = 1; fac2=1
-
     if show_tile_labels and show_colorbar:
         fac2 = 1.15
 
@@ -211,11 +219,9 @@ def plot_tiles(tiles, cmap='jet',
             fac2 = 9.06/9
         
     if layout == 'llc' :
-        if fig_num > 0:
-            f, axarr = plt.subplots(5, 5, num=fig_num)
-        else:
-            f, axarr = plt.subplots(5, 5)
-            
+        nrows=5
+        ncols=5
+
         # plotting of the tiles happens in a 5x5 grid
         # which tile to plot for any one of the 25 spots is indicated with a list
         # a value of negative one means do not plot anything in that spot.
@@ -226,17 +232,14 @@ def plot_tiles(tiles, cmap='jet',
                                 0,  3, -1, -1, -1])
 
     elif layout == 'latlon':
-        if fig_num > 0:
-            f, axarr = plt.subplots(4, 4, num=fig_num)
-        else:
-            f, axarr = plt.subplots(4, 4)
-                  
+        ncols = 4
+        nrows = 4
+
         # plotting of the tiles happens in a 4x4 grid
         # which tile to plot for any one of the 16 spots is indicated with a list
         # a value of negative one means do not plot anything in that spot.
         # the top row will have the Arctic tile.  You can choose where the 
         # Arctic tile goes.  By default it goes in the second column.
-
         if Arctic_cap_tile_location not in [2,5,7,10]:
             print('Arctic Cap Alignment is not one of 2,5,7,10, using 2')
             Arctic_cap_tile_location  = 2    
@@ -261,43 +264,26 @@ def plot_tiles(tiles, cmap='jet',
         # one would use np.concatenate()
         tile_order = tile_order_top_row + tile_order_bottom_rows
 
+    # create fig object
+    if fig_num > 0:
+        f, axarr = plt.subplots(nrows, ncols, num=fig_num)
+    else:
+        f, axarr = plt.subplots(nrows, ncols)
+
     #%%
-    #print(fac1, fac2)
     f.set_size_inches(fac1*fig_size, fig_size*fac2)
 
     if show_tile_labels==False:
         f.subplots_adjust(wspace=0, hspace=0)
     
-    #print(f.get_size_inches())
-
-    #if tile_start_index == -1 and type(tiles) == xr.core.dataarray.DataArray:
-    #    min_tile_num = np.min(tiles.tile.values)
-    #    max_tile_num = np.max(tiles.tile.values)
-
-    #    print (min_tile_num, max_tile_num)
-        
-        #if min_tile_num == 0 and max_tile_num == 12:
-        #    tile_start_index = 0
-        #elif min_tile_num == 1 and max_tile_num == 13:
-        #    tile_start_index = 1
-        #else:
-        #    print ('I cannot guess which index you use for the first tile, 0')
-        #    print ('or 1, using 0')
-        #    tile_start_index = 0
-        
-    #    print ('ts1 = ',  tile_start_index)
-
-    
-    
     # loop through the axes array and plot tiles where tile_order != -1
-    cur_arr = np.zeros((360,360)) 
+    cur_arr = np.zeros((nrows*nx,ncols*nx)) if get_array else None
     for i, ax in enumerate(axarr.ravel()):
         ax.axis('off')
 
         cur_tile_num = tile_order[i]
-        
         have_tile = False
-        #print i, cur_tile_num
+
         if cur_tile_num >= 0:
             if type(tiles) == np.ndarray:
                 have_tile = True
@@ -323,22 +309,11 @@ def plot_tiles(tiles, cmap='jet',
                     cur_tile_num > 6):
                     
                     cur_tile = np.rot90(cur_tile)
-
-                
                     
                 im=ax.imshow(cur_tile, vmin=cmin, vmax=cmax, cmap=cmap, 
                              origin='lower')
-            
-            colnum = 4-1-int(i/4)
-            rownum = i%4 
-            rownump1 = int(rownum + 1)
-            colnump1 = int(colnum + 1)
-            print(type(rownum), type(colnum), type(rownump1))
-            #cur_arr[colnum*90:colnump1*90, rownum*90:rownump1*90] = cur_tile
-            print('i=',i,rownum, colnum)
-            
-            if rownum*colnum>0:
-                cur_arr[colnum*90:colnump1*90, rownum*90:rownump1*90] = cur_tile
+
+            # axis handling
             ax.set_aspect('equal')
             ax.axis('on')
             if show_tile_labels:
@@ -346,6 +321,17 @@ def plot_tiles(tiles, cmap='jet',
                 
             ax.get_xaxis().set_visible(False)
             ax.get_yaxis().set_visible(False)
+
+            # Generate array from this process
+            colnum = ncols-1-int(i/ncols)
+            rownum = i%nrows
+            rownump1 = int(rownum + 1)
+            colnump1 = int(colnum + 1)
+            if not less_output:
+                print('i=',i,rownum, colnum)
+            
+            if rownum*colnum>0 and get_array:
+                cur_arr[colnum*90:colnump1*90, rownum*90:rownump1*90] = cur_tile
 
     # show the colorbar
     if show_colorbar:

--- a/ecco_v4_py/tile_plot_proj.py
+++ b/ecco_v4_py/tile_plot_proj.py
@@ -18,6 +18,7 @@ from cartopy._crs import PROJ4_VERSION
 import cartopy.feature as cfeature
 from .resample_to_latlon import resample_to_latlon
 
+from .plot_utils import assign_colormap
 
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%    
 def plot_proj_to_latlon_grid(lons, lats, data, 
@@ -113,17 +114,7 @@ def plot_proj_to_latlon_grid(lons, lats, data,
         when mapping to the new grid
     """
 
-    #%%    
-    # If data span positive/negative, default to normalize about 0
-    # otherwise, regular (sequential). Assign cmap accordingly.
-    cmin = np.nanmin(data)
-    cmax = np.nanmax(data)
-    if cmin*cmax<0:
-        cmax=np.nanmax(np.abs(data))
-        cmin=-cmax
-        cmap = 'RdBu_r' if cmap is None else cmap
-    else:
-        cmap = 'viridis' if cmap is None else cmap
+    cmap, (cmin,cmax) = assign_colormap(data,cmap)
 
     for key in kwargs:
         if key == "cmin":


### PR DESCRIPTION
This fixes the tile_plot bug, addressing #89. It adds the following:
- a small generalization in the array creation during `plot_tiles`. Previously, the number of rows and columns used for the array were hard coded as 4, but this is only true for `layout='latlon'`, for `layout='llc'`, ncol=nrow=5
- a check to make sure it is llc90 output, otherwise don't make the array 
- match colormap defaults created in #87 and created `plot_utils` to do this for both projection and tile plotting
- clean up debug statements and comments

Last but not least, this adds two modules which can be used with [pytest](https://docs.pytest.org/en/latest/) that basically run through all of the different input configurations and makes sure (1) the plotting script doesn't break and (2) the output array is correct. 

@ifenty @owang01 it would be great if you could check this out and let me know what you think!