### PR TITLE
Init travis and codecov

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,14 @@
+# Useful links in setting up:
+# https://github.com/codecov/example-python
+# https://coverage.readthedocs.io/en/latest/config.html
+# also, I looked at xgcm/xmitgcm as "templates"
+[run]
+branch = True
+
+[report]
+exclude_lines =
+    raise NotImplementedError
+    if __name__ == .__main__.:
+ignore_errors = True 
+omit = ecco_v4_py/test/*
+       ecco_v4_py/__init__.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,46 @@
+# Based on xgcm's .travis.yml and
+# https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/use-conda-with-travis-ci.html 
+language: python
+sudo: false # use container based build
+notifications:
+  email: false
+
+matrix:
+  fast_finish: true
+  include:
+  - python: 3.7
+    env: CONDA_ENV=py37
+
+before_install:
+  - wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+  - bash miniconda.sh -b -p $HOME/miniconda
+    #  - source "$HOME/miniconda/etc/profile.d/conda.sh"
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  - conda info -a
+  - conda list
+
+install:
+  - conda env create --file ci/environment-$CONDA_ENV.yml
+  - source activate test_env_ecco
+  - python -c "import xarray; print(xarray.__version__)"
+
+# note from xgcm version:   
+# if we do this, the package gets installed into
+# /home/travis/build/xgcm/xgcm/build/lib/xgcm
+#  - python setup.py install
+  - pip install -e .
+# this puts the package into
+# /home/travis/build/xgcm/xgcm/xgcm
+# That turns out to be necessary for py.test to correctly collect the tests
+# and for coverage to work properly.
+# It is very complicated and confusing.
+# ^^ wow I'm glad I didn't have to figure that out.
+
+script:
+  - py.test ecco_v4_py -v --cov=ecco_v4_py --cov-config .coveragerc
+
+after_success:
+  - codecov --token=5abbcfb9-fcf6-431d-bda6-6e5b5e8132c8

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ install:
 # ^^ wow I'm glad I didn't have to figure that out.
 
 script:
-  - py.test ecco_v4_py -v --cov=ecco_v4_py --cov-config .coveragerc
+  - py.test ecco_v4_py -v --cov=ecco_v4_py --cov-config .coveragerc --ignore=ecco_v4_py/test/test_generate_ecco_netcdf_product.py
 
 after_success:
   - codecov --token=5abbcfb9-fcf6-431d-bda6-6e5b5e8132c8

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,4 +43,4 @@ script:
   - py.test ecco_v4_py -v --cov=ecco_v4_py --cov-config .coveragerc --ignore=ecco_v4_py/test/test_generate_ecco_netcdf_product.py
 
 after_success:
-  - codecov --token=5abbcfb9-fcf6-431d-bda6-6e5b5e8132c8
+  - codecov #--token=5abbcfb9-fcf6-431d-bda6-6e5b5e8132c8

--- a/ci/environment-py37.yml
+++ b/ci/environment-py37.yml
@@ -1,0 +1,20 @@
+# following xgcm ci environment specs
+name: test_env_ecco
+channels:
+  - conda-forge
+dependencies:
+  - python=3.7
+  - xarray
+  - dask
+  - numpy
+  - scipy
+  - pytest
+  - future
+  - xmitgcm
+  - xgcm
+  - pytest 
+  - codecov
+  - pytest-cov
+  - pyresample
+  - cartopy
+  - docrep

--- a/ecco_v4_py/test/test_llc_array_conversion.py
+++ b/ecco_v4_py/test/test_llc_array_conversion.py
@@ -7,7 +7,7 @@ import pytest
 import ecco_v4_py as ecco
 
 # Define bin directory for test reading
-_PKG_DIR = Path.cwd().resolve().parent.parent
+_PKG_DIR = Path(__file__).resolve().parent.parent
 _DATA_DIR = _PKG_DIR.joinpath('binary_data')
 
 _TEST_FILES = ['basins.data', 'hFacC.data', 'state_3d_set1.0000000732.data']

--- a/ecco_v4_py/test/test_llc_array_conversion.py
+++ b/ecco_v4_py/test/test_llc_array_conversion.py
@@ -7,7 +7,7 @@ import pytest
 import ecco_v4_py as ecco
 
 # Define bin directory for test reading
-_PKG_DIR = Path(__file__).resolve().parent.parent
+_PKG_DIR = Path(__file__).resolve().parent.parent.parent
 _DATA_DIR = _PKG_DIR.joinpath('binary_data')
 
 _TEST_FILES = ['basins.data', 'hFacC.data', 'state_3d_set1.0000000732.data']

--- a/ecco_v4_py/test/test_plot_utils.py
+++ b/ecco_v4_py/test/test_plot_utils.py
@@ -11,12 +11,10 @@ import ecco_v4_py as ecco
 from ecco_v4_py.plot_utils import assign_colormap
 
 # Define bin directory for test reading
-_PKG_DIR = Path.cwd().resolve().parent.parent
+_PKG_DIR = Path(__file__).resolve().parent.parent.parent
 _DATA_DIR = _PKG_DIR.joinpath('binary_data')
 
 _TEST_FILES = ['basins.data', 'hFacC.data', 'state_3d_set1.0000000732.data']
-_TEST_NK = [1, 50, 50]
-_TEST_RECS = [1, 1, 3]
 
 def get_test_array(is_xda=False):
     """define a numpy and xarray DataArray for testing"""

--- a/ecco_v4_py/test/test_tile_plot.py
+++ b/ecco_v4_py/test/test_tile_plot.py
@@ -11,14 +11,6 @@ import ecco_v4_py as ecco
 
 from .test_plot_utils import get_test_array
 
-# Define bin directory for test reading
-_PKG_DIR = Path.cwd().resolve().parent.parent
-_DATA_DIR = _PKG_DIR.joinpath('binary_data')
-
-_TEST_FILES = ['basins.data', 'hFacC.data', 'state_3d_set1.0000000732.data']
-_TEST_NK = [1, 50, 50]
-_TEST_RECS = [1, 1, 3]
-
 @pytest.mark.parametrize("vdict",[
         {}, #defaults
         {'cmap':'plasma'},


### PR DESCRIPTION
This adds the necessary configuration files for travis-ci and codecov. Also, cleans up some of the tests ...

A quick outline:
- .travis.yml: this tells travis (the package that runs an automated test suite) how to run the test, basically by installing miniconda creating a conda environment with all of our packages specified in ci/environment-37.yml. Then it runs the test with the line: 

```
script:
  - py.test ecco_v4_py -v --cov=ecco_v4_py --cov-config .coveragerc --ignore=ecco_v4_py/test/test_generate_ecco_netcdf_product.py
```

where for now we need to ignore test_generate_ecco_netcdf_product.py because, for instance, it doesn't see the directory /Users/ifenty/ etc ... so we need to replace this with something more general when we can. 

- note that we are using the version of pytest called pytest-cov, which has a "coverage"  package built into it, basically saying how much of the code is covered with tests (it's a low number for now!)

- then the coverage report is sent to codecov, which presents it in a nice way for us to understand what's covered etc. How this is done is specified with .coveragerc . Still figuring out the details of what should/shouldn't go in there.

This is a work in progress, but a good start I think!