### PR TITLE
Cleanup setup

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,5 @@
-graft ecco_v4_py meta_json bin
+graft ecco_v4_py 
+graft meta_json 
+graft binary_data
 global-exclude *py[cod] __pycache__ *so
 include LICENSE.txt

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 graft ecco_v4_py meta_json bin
 global-exclude *py[cod] __pycache__ *so
+include LICENSE.txt

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ setup(
 	'cartopy',
 	'xgcm',
         'future',
-        'numpy',
         'pathlib'],
   tests_require=['pytest','coverage'],
   license='MIT',

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ setup(
   data_files=[('binary_data',['binary_data/basins.data', 'binary_data/basins.meta'])],
   install_requires=[
 	'dask[complete]',
-	'datetime',
 	'python-dateutil',
 	'matplotlib',
 	'numpy',

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,12 @@ setup(
 	'xarray',
 	'xmitgcm',
 	'cartopy',
-	'xgcm'],
+	'xgcm',
+        'future',
+        'numpy',
+        'pathlib'],
   tests_require=['pytest','coverage'],
+  license='MIT',
   classifiers=[
       'Development Status :: 5 - Production/Stable',
       'Intended Audience :: Science/Research', 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,9 @@
 from setuptools import setup
 
+def README():
+    with open('README.md') as f:
+        return f.read()
+
 setup(
   name = 'ecco_v4_py',
   packages = ['ecco_v4_py'], # this must be the same as the name above
@@ -35,5 +39,7 @@ setup(
       'Programming Language :: Python',
       'Programming Language :: Python :: 3.7',
       'Topic :: Scientific/Engineering :: Physics'
-  ]
+  ],
+  long_description=README(),
+  long_description_content_type='text/markdown'
 )

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,4 @@
-import setuptools
-
-from distutils.core import setup
+from setuptools import setup
 
 setup(
   name = 'ecco_v4_py',
@@ -14,10 +12,6 @@ setup(
   include_package_data=True,
   data_files=[('binary_data',['binary_data/basins.data', 'binary_data/basins.meta'])],
   install_requires=[
-	'cython',
-	'shapely',
-	'proj',
-	'six',
 	'dask[complete]',
 	'datetime',
 	'python-dateutil',
@@ -26,12 +20,9 @@ setup(
 	'pyresample',
 	'xarray',
 	'xmitgcm',
-	'pyyaml',
-	'pyproj',
-	'pykdtree',
 	'cartopy',
- 'cmocean',
 	'xgcm'],
+  tests_require=['pytest','coverage'],
   classifiers=[
       'Development Status :: 5 - Production/Stable',
       'Intended Audience :: Science/Research', 


### PR DESCRIPTION
This does a few things to clean up the installation process via pip. Namely:

1. add a couple of package dependencies that were missing (although some are obvious). This includes `numpy`, `pathlib` (which is native only to python version >=3.4, and `future`
2. remove some packages which are not critical to ecco_v4_py, following guidance [e.g. shown here](https://packaging.python.org/discussions/install-requires-vs-requirements/#install-requires). This includes: `cmocean`, `cython`, `pykdtree` etc... These are no doubt cool and useful packages, but are not required for minimal installation. Additionally, packages like `pykdtree` are required, but this is a requirement for `pyresample`, and so we should not require it, but get it through `pyresample`
3. `distutils.setup` replaced by `setuptools.setup` since it [seems to be the more advanced version](https://setuptools.readthedocs.io/en/latest/setuptools.html)
4. add license to setup.py
5. add readme to setup.py so it shows up on pypi