### PR TITLE
Print only if less_output is not True

### DIFF
--- a/ecco_v4_py/read_bin_llc.py
+++ b/ecco_v4_py/read_bin_llc.py
@@ -447,7 +447,8 @@ def load_ecco_vars_from_mds(mds_var_dir,
         ecco_dataset.time.attrs['long_name'] = 'snapshot time'
 
     # set averaging period duration and resolution
-    print('\n... setting time coverage resolution')
+    if not less_output:
+    	print('\n... setting time coverage resolution')
     # --- AVG DAY
     if output_freq_code == 'AVG_MON':
         ecco_dataset.attrs['time_coverage_duration'] = 'P1M'


### PR DESCRIPTION
Add an if statement before the print statement (line 450)
print('\n... setting time coverage resolution')

The new version prints out the message only if less_outout is False
if not less_output:
         print('\n... setting time coverage resolution')
