### PR TITLE
Minor fixes to plotting and loading mds files

### DIFF
--- a/ecco_v4_py/read_bin_llc.py
+++ b/ecco_v4_py/read_bin_llc.py
@@ -428,6 +428,7 @@ def load_ecco_vars_from_mds(mds_var_dir,
             # drop 3D coords
             if not less_output:
                 print('\n dropping 3D coords')
+
             coords_to_drop = []
             for coord in list(ecco_dataset.coords):
                 coord_dims = set(ecco_dataset.coords[coord].dims)
@@ -435,7 +436,7 @@ def load_ecco_vars_from_mds(mds_var_dir,
                 if len(coord_tmp) > 0:
                     if not less_output:
                         print('--> dropping ', coord)
-                        ecco_dataset = ecco_dataset.drop(coord)
+                    ecco_dataset = ecco_dataset.drop(coord)
 
     # apply global metadata
     if len(global_metadata) > 0:

--- a/ecco_v4_py/resample_to_latlon.py
+++ b/ecco_v4_py/resample_to_latlon.py
@@ -119,11 +119,11 @@ def resample_to_latlon(orig_lons, orig_lats, orig_field,
         new_grid_lon_centers, new_grid_lat_centers =\
             np.meshgrid(new_grid_lon_centers_1D, new_grid_lat_centers_1D)
 
-        print(np.min(new_grid_lon_centers), np.max(new_grid_lon_centers))
-        print(np.min(new_grid_lon_edges), np.max(new_grid_lon_edges))
+        #print(np.min(new_grid_lon_centers), np.max(new_grid_lon_centers))
+        #print(np.min(new_grid_lon_edges), np.max(new_grid_lon_edges))
         
-        print(np.min(new_grid_lat_centers), np.max(new_grid_lat_centers))
-        print(np.min(new_grid_lat_edges), np.max(new_grid_lat_edges)) 
+        #print(np.min(new_grid_lat_centers), np.max(new_grid_lat_centers))
+        #print(np.min(new_grid_lat_edges), np.max(new_grid_lat_edges)) 
         
         # define the lat lon points of the two parts.
         new_grid  = pr.geometry.GridDefinition(lons=new_grid_lon_centers,

--- a/ecco_v4_py/tile_plot.py
+++ b/ecco_v4_py/tile_plot.py
@@ -278,6 +278,7 @@ def plot_tiles(tiles, cmap=None,
     
     # loop through the axes array and plot tiles where tile_order != -1
     cur_arr = np.zeros((nrows*nx,ncols*nx)) if get_array else None
+    cur_tile = -1
     for i, ax in enumerate(axarr.ravel()):
         ax.axis('off')
 
@@ -291,7 +292,7 @@ def plot_tiles(tiles, cmap=None,
                     
             elif isinstance(tiles, dask.array.core.Array) or \
                  isinstance(tiles, xr.core.dataarray.DataArray):
-                
+
                 if cur_tile_num in tiles.tile :
                     have_tile = True
                     cur_tile = tiles.sel(tile=cur_tile_num)

--- a/ecco_v4_py/tile_plot_proj.py
+++ b/ecco_v4_py/tile_plot_proj.py
@@ -244,8 +244,11 @@ def plot_proj_to_latlon_grid(lons, lats, data,
                          grid_linestyle = grid_linestyle,
                          colorbar_label = colorbar_label,
                          less_output=less_output)
-    
-           
+
+        new_grid_lon_centers_out = new_grid_lon_centers
+        new_grid_lat_centers_out = new_grid_lat_centers
+        data_latlon_projection_out = data_latlon_projection
+
     else: # not polar stereographic projection
     
         # To avoid plotting problems around the date line, lon=180E, -180W


### PR DESCRIPTION
before the model start date was hard coded (1992-01-01T12:00:00). now that we are running "extension" simulations with a later start date, it is better to pass the start date as an argument when loading mds files.

there were some bugs in plotting routines for polar stereographic projections and in plot_tiles when tile 0 was missing. 

finally, the helper routine to load mds files wasn't properly dropping 3D coordinates after loading a 2D field when 'drop_unused_coords'=True.  Fixed now.