### PR TITLE
Add a new argument circle_boundary for plot_proj_to_latlon_grid

### DIFF
--- a/ecco_v4_py/tile_plot_proj.py
+++ b/ecco_v4_py/tile_plot_proj.py
@@ -27,6 +27,7 @@ def plot_proj_to_latlon_grid(lons, lats, data,
                              mapping_method='nearest_neighbor',
                              radius_of_influence = 112000,
                              plot_type = 'pcolormesh',
+                             circle_boundary = False,
                              cmap = None,
                              cmin = None, 
                              cmax = None,
@@ -103,6 +104,9 @@ def plot_proj_to_latlon_grid(lons, lats, data,
             'pcolormesh' - pcolormesh
             'contourf' - filled contour
             'points' - plot points at lat/lon locations
+
+    circle_boundary : logical, optional, default False
+        use a circle boundary or not 
     
     cmap : matplotlib.colors.Colormap, optional, default None
         a colormap for the figure.  
@@ -232,6 +236,7 @@ def plot_proj_to_latlon_grid(lons, lats, data,
                          lat_lim,
                          cmin, cmax, ax,
                          plot_type = plot_type,
+                         circle_boundary = circle_boundary,
                          cmap = cmap,
                          show_coastline = show_coastline,
                          show_colorbar = show_colorbar,
@@ -317,6 +322,7 @@ def plot_proj_to_latlon_grid(lons, lats, data,
                               data_epsg_code,
                               cmin, cmax, ax,
                               plot_type = plot_type,
+                              circle_boundary = circle_boundary,
                               cmap = cmap,
                               show_coastline = show_coastline,
                               show_colorbar = show_colorbar,


### PR DESCRIPTION
Add a new argument circle_boundary for plot_proj_to_latlon_grid. The default is False so not plot a circular boundary for the figure. 