### PR TITLE
vector rotation from vector fields defined on tracer cell centers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.pyc
 *.swp
 
+ecco_v4_py/.ipynb_checkpoints/read_bin_llc-checkpoint.py
+.DS_Store

--- a/.ipynb_checkpoints/Untitled-checkpoint.ipynb
+++ b/.ipynb_checkpoints/Untitled-checkpoint.ipynb
@@ -1,6 +1,0 @@
-{
- "cells": [],
- "metadata": {},
- "nbformat": 4,
- "nbformat_minor": 5
-}

--- a/.ipynb_checkpoints/Untitled-checkpoint.ipynb
+++ b/.ipynb_checkpoints/Untitled-checkpoint.ipynb
@@ -1,0 +1,6 @@
+{
+ "cells": [],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/ecco_v4_py/vector_calc.py
+++ b/ecco_v4_py/vector_calc.py
@@ -7,27 +7,36 @@ import xgcm
 from .ecco_utils import get_llc_grid
 
 
-def UEVNfromUXVY(xfld,yfld,coords,grid=None):
-    """Compute east, north facing vector field components from x, y components
-    by interpolating to cell centers and rotating by grid cell angle
+def UEVNfromUXVY(x_fld,y_fld, coords, grid=None):
+    """Compute the zonal and meridional components of a vector field defined
+    by its x and y components with respect to the model grid.
 
-    Note: this mirrors gcmfaces_calc/calc_UEVNfromUXVY.m
+    The x and y components of the vector can be defined on model grid cell edges ('u' and 'v' points),
+    or on model grid cell centers ('c' points). If the vector components are defined on the grid cell edges then the function will first interpolate them to the grid cell centers. 
+    
+    Once both x and y vector components are at the cell centers, they are rotated to the zonal and meridional components using the cosine and sine of the grid cell angle. The grid cell angle is defined as the angle between the Earth's parallels and the line connecting the center of a grid cell to the center of its neighbor in the x-direction. The cosine and sine of this angle are provided in the 'coords' input field.
+
+    The function will raise an error if the grid cell angle terms (CS, SN) are not provided in the coords
+
+    Example vector fields provided at the grid cell edges are UVEL and VVEL. Example fields provided at the grid cell centers are EXFuwind and EXFvwind. 
+
+    Note: this routine is inspired by gcmfaces_calc/calc_UEVNfromUXVY.m
 
     Parameters
     ----------
-    xfld, yfld : xarray DataArray
-        fields living on west and south grid cell edges, e.g. UVELMASS and VVELMASS
+    x_fld, y_fld : xarray DataArray
+        x and y components of a vector field provided at the model grid cell edges or centers
     coords : xarray Dataset
-        must contain CS (cosine of grid orientation) and
-        SN (sine of grid orientation)
+        must contain CS (cosine of grid orientation) and SN (sine of grid orientation)
     grid : xgcm Grid object, optional
         see ecco_utils.get_llc_grid and xgcm.Grid
-
+        If not provided, the function will create one using the coords dataset.
+    
     Returns
     -------
-    u_east, v_north : xarray DataArray
-        eastward and northward components of input vector field at
-        grid cell center/tracer points
+    e_fld, n_fld : xarray DataArray
+        zonal (positive east) and meridional (positive north) components of input vector field 
+        at grid cell centers/tracer points
     """
 
     # Check to make sure 'CS' and 'SN' are in coords
@@ -41,14 +50,31 @@ def UEVNfromUXVY(xfld,yfld,coords,grid=None):
     if grid is None:
         grid = get_llc_grid(coords)
 
-    # First, interpolate velocity fields from cell edges to cell centers
-    velc = grid.interp_2d_vector({'X': xfld, 'Y': yfld},boundary='fill')
+    # Determine if vector fields are at cell edges or cell centers
+    # by checking the dimensions of the x and y fields
+    # If the vector components are at cell edges, we need to interpolate to cell centers
+    # If the vector components are at cell centers, we don't need to interpolate
+    # Create a set with all of the dimensions of the x and y fields
+    vector_dims = set(x_fld.dims + y_fld.dims)
+    
+    # if neither 'i_g' and 'j_g' are present then the vector components are at cell centers
+    vector_components_at_cell_center = 'i_g' not in vector_dims and 'j_g' not in vector_dims
 
-    # Compute UE VN using cos(), sin()
-    u_east = velc['X']*coords['CS'] - velc['Y']*coords['SN']
-    v_north= velc['X']*coords['SN'] + velc['Y']*coords['CS']
+    if vector_components_at_cell_center:
+        # If the vector components are at cell centers, we don't need to interpolate
+        # vec_field is a dictionary with the x and y fields
+        vec_field = {'X': x_fld, 'Y': y_fld}
+    else:
+        # If the vector components are at cell edges, we need to interpolate to cell centers
+        # vec_field is a dictionary with the x and y fields
+        vec_field = grid.interp_2d_vector({'X': x_fld, 'Y': y_fld},boundary='fill')
+        
+    # Compute the zonal "e" and meridional components "n" using cos(), sin()
+    e_fld = vec_field['X']*coords['CS'] - vec_field['Y']*coords['SN']
+    n_fld = vec_field['X']*coords['SN'] + vec_field['Y']*coords['CS']
 
-    return u_east, v_north
+    return e_fld, n_fld
+
 
 
 def get_latitude_masks(lat_val,yc,grid):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,14 @@
+numpy
+future
+numpy
+Bottleneck
+Cartopy
+cmocean
+dask[complete]
+matplotlib
+netCDF4
+pyresample
+python-dateutil
+xarray
+xmitgcm
+xgcm

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def README():
 setup(
   name = 'ecco_v4_py',
   packages = ['ecco_v4_py'], # this must be the same as the name above
-  version = '1.6.1',
+  version = '1.7.1',
   description = 'Estimating the Circulation and Climate of the Ocean (ECCO) Version 4 Python Package',
   author = 'Ian Fenty, Ou Wang, Tim Smith, and others',
   author_email = 'ian.fenty@jpl.nasa.gov, ecco-group@mit.edu',
@@ -17,11 +17,11 @@ setup(
   data_files=[('binary_data',['binary_data/basins.data', 'binary_data/basins.meta'])],
   python_requires = '>=3.7',
   install_requires=[
-    'numpy',
+  'numpy',
 	'future',
-    'numpy',
-    'Bottleneck',
-  	'Cartopy',
+  'numpy',
+  'Bottleneck',
+  'Cartopy',
 	'cmocean',
 	'dask[complete]',
 	'matplotlib',


### PR DESCRIPTION
added requirements.txt, info taken from setup.py

added functionality to vector_calc.py to calculate the rotation of a vector defined on the tracer cell centers. Before this update, the vector rotation subroutine only worked for vector fields defined on the cell edges.

updated version number to 1.7.1